### PR TITLE
CKKSInstance Bugfix

### DIFF
--- a/src/CKKSInstance.cpp
+++ b/src/CKKSInstance.cpp
@@ -444,20 +444,26 @@ int CKKSInstance::genModulusVec(int numPrimes, vector<int> &modulusVector) {
 }
 
 void CKKSInstance::setMaxVal(const vector<double> &plain) {
-  if(mode == SCALE || mode == DEBUG) {
-    double maxVal = 0;
-    for(int i = 0; i < plain.size(); i++) {
-      maxVal = max(maxVal, abs(plain[i]));
-    }
+  double maxVal = lInfNorm(plain);
 
-    if(mode == SCALE) {
+  switch(mode) {
+    case SCALE: {
       ScaleEstimator *e = dynamic_cast<ScaleEstimator*>(evaluator);
       e->updatePlaintextMaxVal(maxVal);
+      break;
     }
-    else {
+    case DEBUG: {
       DebugEval *e = dynamic_cast<DebugEval*>(evaluator);
       e->updatePlaintextMaxVal(maxVal);
+      break;
     }
+    case PLAINTEXT: {
+      PlaintextEval *e = dynamic_cast<PlaintextEval*>(evaluator);
+      e->updatePlaintextMaxVal(maxVal);
+      break;
+    }
+    default:
+      break;
   }
 }
 

--- a/src/api/evaluator/plaintext.cpp
+++ b/src/api/evaluator/plaintext.cpp
@@ -48,6 +48,11 @@ void PlaintextEval::updateMaxLogPlainVal(const CKKSCiphertext &c) {
   ptMaxLog = max(ptMaxLog, log2(exactPlaintextMaxVal));
 }
 
+void PlaintextEval::updatePlaintextMaxVal(double x) {
+  // takes the actual max value, we need to set the log of it
+  ptMaxLog = max(ptMaxLog, log2(x));
+}
+
 CKKSCiphertext PlaintextEval::rotate_vector_right_internal(const CKKSCiphertext &encrypted, int steps) {
   CKKSCiphertext dest = encrypted;
   vector<double> rot_temp;

--- a/src/api/evaluator/plaintext.h
+++ b/src/api/evaluator/plaintext.h
@@ -26,7 +26,10 @@ public:
   // this is useful for putting an upper bound on the scale parameter
   double getExactMaxLogPlainVal() const;
 
-  void updateMaxLogPlainVal(const CKKSCiphertext &c);
+  // primarily used to indicate the maximum value for each *input* to the function.
+  // For functions which are a no-op, this function is the only way the evaluator
+  // can learn the maximum plaintext values.
+  void updatePlaintextMaxVal(double x);
 
 protected:
   virtual CKKSCiphertext rotate_vector_right_internal(const CKKSCiphertext &encrypted, int steps) override;
@@ -60,6 +63,7 @@ protected:
 
 private:
   void print_stats(const CKKSCiphertext &c);
+  void updateMaxLogPlainVal(const CKKSCiphertext &c);
   double ptMaxLog;
 
   friend class ScaleEstimator;


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
CKKSInstance was not updating the maximum plaintext value in the Plaintext evaluator during encryption. This PR fixes that bug.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
