### PR TITLE
Changed protobuf namespace from protobuf::hit to hit::protobuf

### DIFF
--- a/protobuf/ciphertext.proto
+++ b/protobuf/ciphertext.proto
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 syntax = "proto2";
-package protobuf.hit;
+package hit.protobuf;
 
 message Ciphertext {
 	required int32 version = 1;

--- a/protobuf/ckksparams.proto
+++ b/protobuf/ckksparams.proto
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 syntax = "proto2";
-package protobuf.hit;
+package hit.protobuf;
 
 message CKKSParams {
 	required int32 version = 1;

--- a/src/hit/CKKSInstance.cpp
+++ b/src/hit/CKKSInstance.cpp
@@ -68,8 +68,8 @@ namespace hit {
         return new CKKSInstance(paramsStream, nullptr, nullptr, &secretKeyStream, NONEVALUATION);
     }
 
-    protobuf::hit::CKKSParams CKKSInstance::save_ckks_params() {
-        protobuf::hit::CKKSParams p;
+    protobuf::CKKSParams CKKSInstance::save_ckks_params() {
+        protobuf::CKKSParams p;
 
         p.set_version(0);
         auto context_data = context->key_context_data();
@@ -203,7 +203,7 @@ namespace hit {
     CKKSInstance::CKKSInstance(istream &paramsStream, istream *galoisKeyStream, istream *relinKeyStream,
                                istream *secretKeyStream, Mode m) {
         mode = m;
-        protobuf::hit::CKKSParams ckksParams;
+        protobuf::CKKSParams ckksParams;
         ckksParams.ParseFromIstream(&paramsStream);
         logScale = ckksParams.logscale();
         int numSlots = ckksParams.numslots();
@@ -284,7 +284,7 @@ namespace hit {
             sk.save(*secretKeyStream);
         }
         if (paramsStream != nullptr) {
-            protobuf::hit::CKKSParams ckksParams = save_ckks_params();
+            protobuf::CKKSParams ckksParams = save_ckks_params();
             ckksParams.SerializeToOstream(paramsStream);
         }
         if (galoisKeyStream != nullptr) {

--- a/src/hit/CKKSInstance.h
+++ b/src/hit/CKKSInstance.h
@@ -147,7 +147,7 @@ namespace hit {
         int gen_modulus_vec(int numPrimes, std::vector<int> &modulusVector) const;
         void set_max_val(const std::vector<double> &plain);
         void shared_param_init(int numSlots, int multDepth, int logScaleIn, bool useSEALParams);
-        protobuf::hit::CKKSParams save_ckks_params();
+        hit::protobuf::CKKSParams save_ckks_params();
 
         seal::Encryptor *sealEncryptor;
         seal::CKKSEncoder *encoder;

--- a/src/hit/api/ciphertext.cpp
+++ b/src/hit/api/ciphertext.cpp
@@ -28,7 +28,7 @@ namespace hit {
         scale = src.scale;
     }
 
-    CKKSCiphertext::CKKSCiphertext(const shared_ptr<SEALContext> &context, const protobuf::hit::Ciphertext &proto_ct) {
+    CKKSCiphertext::CKKSCiphertext(const shared_ptr<SEALContext> &context, const protobuf::Ciphertext &proto_ct) {
         if (proto_ct.version() != 0) {
             throw invalid_argument("CKKSCiphertext serialization: Expected version 0");
         }
@@ -68,13 +68,13 @@ namespace hit {
         return decodePlaintext(encoded_pt.data(), encoding, height, width, encoded_height, encoded_width);
     }
 
-    protobuf::hit::Ciphertext *CKKSCiphertext::save() const {
-        auto *proto_ct = new protobuf::hit::Ciphertext();
+    protobuf::Ciphertext *CKKSCiphertext::save() const {
+        auto *proto_ct = new protobuf::Ciphertext();
         save(proto_ct);
         return proto_ct;
     }
 
-    void CKKSCiphertext::save(protobuf::hit::Ciphertext *proto_ct) const {
+    void CKKSCiphertext::save(protobuf::Ciphertext *proto_ct) const {
         proto_ct->set_version(0);
         proto_ct->set_height(height);
         proto_ct->set_encoded_height(encoded_height);

--- a/src/hit/api/ciphertext.h
+++ b/src/hit/api/ciphertext.h
@@ -48,7 +48,7 @@ namespace hit {
         // A default constructor is useful since we often write, e.g, `Ciphertext &a;`
         CKKSCiphertext();
 
-        CKKSCiphertext(const std::shared_ptr<seal::SEALContext> &context, const protobuf::hit::Ciphertext &proto_ct);
+        CKKSCiphertext(const std::shared_ptr<seal::SEALContext> &context, const hit::protobuf::Ciphertext &proto_ct);
 
         // Copy all members except the ciphertext itself
         void copyMetadataFrom(const CKKSCiphertext &src);
@@ -62,7 +62,7 @@ namespace hit {
 
         std::vector<double> getPlaintext() const;
 
-        protobuf::hit::Ciphertext *save() const;
-        void save(protobuf::hit::Ciphertext *proto_ct) const;
+        hit::protobuf::Ciphertext *save() const;
+        void save(hit::protobuf::Ciphertext *proto_ct) const;
     };
 }  // namespace hit


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This PR changes the protobuf namespace from protobuf::hit to hit::protobuf.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
