### PR TITLE
Ct serialization warning

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ install/*
 *.unison*
 .vscode/
 lib/*
+hit_log/*
 
 # Ignore third party.
 third-party/*/**

--- a/src/hit/api/ciphertext.cpp
+++ b/src/hit/api/ciphertext.cpp
@@ -5,6 +5,8 @@
 
 #include "../common.h"
 
+#include <glog/logging.h>
+
 using namespace std;
 using namespace seal;
 
@@ -75,6 +77,10 @@ namespace hit {
     }
 
     void CKKSCiphertext::save(protobuf::Ciphertext *proto_ct) const {
+        if (!encoded_pt.empty()) {
+            LOG(WARNING) << "Serializing ciphertext with plaintext data attached! Use the homomorphic evaluator instead for secure computation.";
+        }
+
         proto_ct->set_version(0);
         proto_ct->set_height(height);
         proto_ct->set_encoded_height(encoded_height);


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
I added a warning to ciphertext serialization that issues a warning if the ciphertext object contains plaintext data, since, if done with real data, this would leak supposedly-encrypted information.

I also added hit_log/* to gitignore, since this seems to be where something is outputting logs.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
