### PR TITLE
Set TBB_IMPORTED_TARGETS to tbb when TBB is found on the system

### DIFF
--- a/cmake/modules/FindTbbLib.cmake
+++ b/cmake/modules/FindTbbLib.cmake
@@ -5,6 +5,7 @@ message(STATUS "Searching TBB lib.")
 find_package(TBB QUIET)
 if (TBB_FOUND)
     message(STATUS "TBB is found. Skip downloading source code.")
+    set(TBB_IMPORTED_TARGETS tbb)
 else ()
     # https://github.com/oneapi-src/oneTBB/tree/tbb_2020/cmake#tutorials-tbb-integration-using-cmake
     message(STATUS "Downloading and installing TBB since it is not found.")


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
When TBB is installed on the system, TBB_IMPORTED_TARGETS is not set. This PR manually sets TBB_IMPORTED_TARGETS to `tbb` if TBB is installed on the system so that linking succeeds.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
