### PR TITLE
Avoid using system installed tbb.

### DIFF
--- a/cmake/modules/FindTbbLib.cmake
+++ b/cmake/modules/FindTbbLib.cmake
@@ -1,19 +1,13 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-message(STATUS "Searching TBB lib.")
-find_package(TBB QUIET)
-if (TBB_FOUND)
-    message(STATUS "TBB is found. Skip downloading source code.")
-else ()
-    # https://github.com/oneapi-src/oneTBB/tree/tbb_2020/cmake#tutorials-tbb-integration-using-cmake
-    message(STATUS "Downloading and installing TBB since it is not found.")
-    download_external_project("tbb")
-    set(TBB_CONTENT_DIR ${HIT_THIRD_PARTY_DIR}/tbb/src)
-    set(TBB_BUILD_DIR ${HIT_THIRD_PARTY_DIR}/tbb/build)
-    include(${TBB_CONTENT_DIR}/cmake/TBBBuild.cmake)
-    tbb_build(TBB_ROOT ${TBB_CONTENT_DIR} CONFIG_DIR TBB_BUILD_VAR MAKE_ARGS tbb_build_dir=${TBB_BUILD_DIR})
-    message(STATUS "TBB_BUILD_VAR ${TBB_BUILD_VAR}.")
-    find_package(TBB REQUIRED tbb HINTS ${TBB_BUILD_VAR})
-endif ()
+# https://github.com/oneapi-src/oneTBB/tree/tbb_2020/cmake#tutorials-tbb-integration-using-cmake
+message(STATUS "Downloading and installing TBB since it is not found.")
+download_external_project("tbb")
+set(TBB_CONTENT_DIR ${HIT_THIRD_PARTY_DIR}/tbb/src)
+set(TBB_BUILD_DIR ${HIT_THIRD_PARTY_DIR}/tbb/build)
+include(${TBB_CONTENT_DIR}/cmake/TBBBuild.cmake)
+tbb_build(TBB_ROOT ${TBB_CONTENT_DIR} CONFIG_DIR TBB_BUILD_VAR MAKE_ARGS tbb_build_dir=${TBB_BUILD_DIR})
+message(STATUS "TBB_BUILD_VAR ${TBB_BUILD_VAR}.")
+find_package(TBB REQUIRED tbb HINTS ${TBB_BUILD_VAR})
 message(STATUS "TBB_VERSION : ${TBB_VERSION}")

--- a/scripts/codebuild/run-hit-ci.sh
+++ b/scripts/codebuild/run-hit-ci.sh
@@ -21,7 +21,6 @@ mkdir -p ${GLOG_log_dir}
 if [ -d build ]; then rm -Rf build; fi
 mkdir -p build && cd build
 cmake -GNinja -DCMAKE_BUILD_TYPE=Release \
-    -DCMAKE_MODULE_PATH=/usr/share/cmake/Modules \
     -DBUILD_HIT_TESTING=ON -DCMake_RUN_CLANG_TIDY=ON \
     -DBUILD_HIT_EXAMPLES=ON ../
 ninja -j $(nproc)


### PR DESCRIPTION
*Issue #, if available:*

N/A

*Description of changes:*

This PR avoids using system installed tbb.
* System installed tbb may not provide CMake module, or define `TBB_IMPORTED_TARGETS`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
