### PR TITLE
Fixed ciphertext serialization and added a unit test

### DIFF
--- a/protobuf/ciphertext.proto
+++ b/protobuf/ciphertext.proto
@@ -5,10 +5,9 @@ syntax = "proto2";
 package hit.protobuf;
 
 message Ciphertext {
-	required int32 version = 1;
-	required bool initialized = 2; // has this ciphertext been initialized?
-	optional bytes seal_ct = 3;    // the underlying SEAL ciphertext
-	required int32 he_level = 4;   // level of this ciphertext
-	repeated double raw_pt = 5;    // raw (unscaled) plaintext encrypted in the ciphertext; only non-empty in debug modes
-	required double scale = 6;     // CKKS scale of this ciphertext
+	required bool initialized = 1; // has this ciphertext been initialized?
+	optional bytes seal_ct = 2;    // the underlying SEAL ciphertext
+	required int32 he_level = 3;   // level of this ciphertext
+	repeated double raw_pt = 4;    // raw (unscaled) plaintext encrypted in the ciphertext; only non-empty in debug modes
+	required double scale = 5;     // CKKS scale of this ciphertext
 }

--- a/src/hit/api/ciphertext.h
+++ b/src/hit/api/ciphertext.h
@@ -21,7 +21,7 @@ namespace hit {
 
         // Serialize a ciphertext
         hit::protobuf::Ciphertext *save() const;
-        void save(hit::protobuf::Ciphertext *proto_ct) const;
+        void save(hit::protobuf::Ciphertext &proto_ct) const;
 
         // Ciphertext metadata
         int num_slots() const override;

--- a/src/hit/api/encryptor.cpp
+++ b/src/hit/api/encryptor.cpp
@@ -62,6 +62,7 @@ namespace hit {
         }
 
         destination.num_slots_ = numSlots;
+        destination.initialized = true;
 
         return destination;
     }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -9,7 +9,7 @@ set(CMAKE_CXX_CLANG_TIDY "")
 find_package(GoogleTestLib REQUIRED)
 
 list(APPEND HIT_TEST_FILES "matrix.cpp" "testutil.cpp")
-add_subdirectory(${CMAKE_CURRENT_LIST_DIR}/api/evaluator)
+add_subdirectory(${CMAKE_CURRENT_LIST_DIR}/api)
 add_executable(hit-unit-test ${HIT_TEST_FILES})
 
 target_link_libraries(hit-unit-test PUBLIC aws-hit gtest gtest_main)

--- a/tests/api/CMakeLists.txt
+++ b/tests/api/CMakeLists.txt
@@ -1,0 +1,9 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+list(APPEND HIT_TEST_FILES
+        "${CMAKE_CURRENT_LIST_DIR}/ciphertext.cpp"
+    )
+set(HIT_TEST_FILES ${HIT_TEST_FILES} PARENT_SCOPE)
+
+add_subdirectory(evaluator)

--- a/tests/api/ciphertext.cpp
+++ b/tests/api/ciphertext.cpp
@@ -1,0 +1,34 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "hit/api/ciphertext.h"
+
+#include <iostream>
+
+#include "../testutil.h"
+#include "gtest/gtest.h"
+#include "hit/CKKSInstance.h"
+#include "hit/common.h"
+
+using namespace std;
+using namespace hit;
+
+// Test variables.
+const int RANGE = 16;
+const int NUM_OF_SLOTS = 4096;
+const int ZERO_MULTI_DEPTH = 0;
+const int LOG_SCALE = 40;
+
+// encrypt a random message, serialize it, deserialize it, and decrypt.
+// ensure that the decrypted message is the same as the original plaintext.
+TEST(SerializationTest, CKKSCiphertext) {
+    CKKSInstance *ckksInstance = CKKSInstance::get_new_homomorphic_instance(NUM_OF_SLOTS, ZERO_MULTI_DEPTH, LOG_SCALE);
+
+    vector<double> vector1 = randomVector(NUM_OF_SLOTS, RANGE);
+    CKKSCiphertext ciphertext1 = ckksInstance->encrypt(vector1);
+    hit::protobuf::Ciphertext *ciphertext1_proto = ciphertext1.save();
+
+    CKKSCiphertext ciphertext2(ckksInstance->context, *ciphertext1_proto);
+    vector<double> vector2 = ckksInstance->decrypt(ciphertext2);
+    ASSERT_LT(diff2Norm(vector1, vector2), MAX_NORM);
+}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
While updating the application tests, I came across a ciphertext serialization test that should be in HIT. After adding that test, I realized that HIT ciphertext serialization wasn't actually working. This PR fixes the problem and adds a serialization test.

It seems this code was pretty out of date. Now, raw_pt and seal_ct are indepedently serialized/deserialized based on whether they are present in the CKKSCiphertext/ProtoCiphertext. Additionally, Encryptor was not setting the `initialized` flag like it was supposed to.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
