### PR TITLE
Made ciphertext serialization consistent

### DIFF
--- a/src/hit/api/ciphertext.cpp
+++ b/src/hit/api/ciphertext.cpp
@@ -40,32 +40,30 @@ namespace hit {
         }
     }
 
-    protobuf::Ciphertext *CKKSCiphertext::save() const {
+    protobuf::Ciphertext *CKKSCiphertext::serialize() const {
         auto *proto_ct = new protobuf::Ciphertext();
-        save(*proto_ct);
-        return proto_ct;
-    }
 
-    void CKKSCiphertext::save(protobuf::Ciphertext &proto_ct) const {
         if (!raw_pt.empty()) {
             LOG(WARNING) << "Serializing ciphertext with plaintext data attached! Use the homomorphic evaluator "
                             "instead for secure computation.";
         }
 
-        proto_ct.set_initialized(initialized);
-        proto_ct.set_scale(scale_);
-        proto_ct.set_he_level(he_level_);
+        proto_ct->set_initialized(initialized);
+        proto_ct->set_scale(scale_);
+        proto_ct->set_he_level(he_level_);
 
         for (double i : raw_pt) {
-            proto_ct.add_raw_pt(i);
+            proto_ct->add_raw_pt(i);
         }
 
         // if the seal_ct is initialized, serialize it
         if (seal_ct.parms_id() != parms_id_zero) {
             ostringstream sealctBuf;
             seal_ct.save(sealctBuf);
-            proto_ct.set_seal_ct(sealctBuf.str());
+            proto_ct->set_seal_ct(sealctBuf.str());
         }
+
+        return proto_ct;
     }
 
     // Metadata interface functions

--- a/src/hit/api/ciphertext.h
+++ b/src/hit/api/ciphertext.h
@@ -20,8 +20,7 @@ namespace hit {
         CKKSCiphertext(const std::shared_ptr<seal::SEALContext> &context, const hit::protobuf::Ciphertext &proto_ct);
 
         // Serialize a ciphertext
-        hit::protobuf::Ciphertext *save() const;
-        void save(hit::protobuf::Ciphertext &proto_ct) const;
+        hit::protobuf::Ciphertext *serialize() const;
 
         // Ciphertext metadata
         int num_slots() const override;

--- a/src/hit/common.h
+++ b/src/hit/common.h
@@ -58,7 +58,7 @@ namespace hit {
         auto *proto_ciphertext_vector = new protobuf::CiphertextVector();
         for (const auto &ciphertext : ciphertext_vector) {
             // https://developers.google.com/protocol-buffers/docs/reference/cpp-generated#repeatedmessage
-            proto_ciphertext_vector->mutable_cts()->AddAllocated(ciphertext.save());
+            proto_ciphertext_vector->mutable_cts()->AddAllocated(ciphertext.serialize());
         }
         return proto_ciphertext_vector;
     }

--- a/tests/api/ciphertext.cpp
+++ b/tests/api/ciphertext.cpp
@@ -26,7 +26,7 @@ TEST(SerializationTest, CKKSCiphertext) {
 
     vector<double> vector1 = random_vector(NUM_OF_SLOTS, RANGE);
     CKKSCiphertext ciphertext1 = ckks_instance->encrypt(vector1);
-    hit::protobuf::Ciphertext *ciphertext1_proto = ciphertext1.save();
+    hit::protobuf::Ciphertext *ciphertext1_proto = ciphertext1.serialize();
 
     CKKSCiphertext ciphertext2(ckks_instance->context, *ciphertext1_proto);
     vector<double> vector2 = ckks_instance->decrypt(ciphertext2);


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Ciphertexts had a different serialization API than linear algebra types. I've determined that the linear algebra serialization is sufficient, so this PR makes the ciphertext serialization API consistent.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
