### PR TITLE
Renamed mod_down_to to reduce_level_to

### DIFF
--- a/examples/evaluator_example.cpp
+++ b/examples/evaluator_example.cpp
@@ -116,7 +116,7 @@ CKKSCiphertext sigmoid(const CKKSCiphertext &x1_encrypted, CKKSEvaluator &eval) 
    * We need to add these two terms together, but that requires them to be at the same
    * level. We solve this problem by multiplying coeff1_x1_encrypted by the scalar 1.
    */
-  eval.mod_down_to_level_inplace(coeff1_x1_encrypted, coeff3_x3_encrypted.he_level());
+  eval.reduce_level_to_inplace(coeff1_x1_encrypted, coeff3_x3_encrypted.he_level());
 
   // add 0.5 and 0.15*x
   CKKSCiphertext result = eval.add_plain(coeff1_x1_encrypted, sigmoid_c0);

--- a/src/hit/api/evaluator.cpp
+++ b/src/hit/api/evaluator.cpp
@@ -191,31 +191,31 @@ namespace hit {
         square_inplace_internal(ct);
     }
 
-    CKKSCiphertext CKKSEvaluator::mod_down_to(const CKKSCiphertext &ct, const CKKSCiphertext &target) {
-        return mod_down_to_level(ct, target.he_level());
+    CKKSCiphertext CKKSEvaluator::reduce_level_to(const CKKSCiphertext &ct, const CKKSCiphertext &target) {
+        return reduce_level_to(ct, target.he_level());
     }
 
-    void CKKSEvaluator::mod_down_to_inplace(CKKSCiphertext &ct, const CKKSCiphertext &target) {
-        mod_down_to_level_inplace(ct, target.he_level());
+    void CKKSEvaluator::reduce_level_to_inplace(CKKSCiphertext &ct, const CKKSCiphertext &target) {
+        reduce_level_to_inplace(ct, target.he_level());
     }
 
-    void CKKSEvaluator::mod_down_to_min_inplace(CKKSCiphertext &ct1, CKKSCiphertext &ct2) {
+    void CKKSEvaluator::reduce_level_to_min_inplace(CKKSCiphertext &ct1, CKKSCiphertext &ct2) {
         if (ct1.he_level() > ct2.he_level()) {
-            mod_down_to_level_inplace(ct1, ct2.he_level());
+            reduce_level_to_inplace(ct1, ct2.he_level());
         } else {
-            mod_down_to_level_inplace(ct2, ct1.he_level());
+            reduce_level_to_inplace(ct2, ct1.he_level());
         }
     }
 
-    CKKSCiphertext CKKSEvaluator::mod_down_to_level(const CKKSCiphertext &ct, int level) {
+    CKKSCiphertext CKKSEvaluator::reduce_level_to(const CKKSCiphertext &ct, int level) {
         CKKSCiphertext output = ct;
-        mod_down_to_level_inplace(output, level);
+        reduce_level_to_inplace(output, level);
         return output;
     }
 
-    void CKKSEvaluator::mod_down_to_level_inplace(CKKSCiphertext &ct, int level) {
+    void CKKSEvaluator::reduce_level_to_inplace(CKKSCiphertext &ct, int level) {
         VLOG(LOG_VERBOSE) << "Decreasing HE level to " << level;
-        mod_down_to_level_inplace_internal(ct, level);
+        reduce_level_to_inplace_internal(ct, level);
     }
 
     CKKSCiphertext CKKSEvaluator::rescale_to_next(const CKKSCiphertext &ct) {

--- a/src/hit/api/evaluator.h
+++ b/src/hit/api/evaluator.h
@@ -175,26 +175,26 @@ namespace hit {
 
         /* Reduce the HE level of `x` to the level of the `target`.
          */
-        CKKSCiphertext mod_down_to(const CKKSCiphertext &ct, const CKKSCiphertext &target);
+        CKKSCiphertext reduce_level_to(const CKKSCiphertext &ct, const CKKSCiphertext &target);
 
         /* Reduce the HE level of `x` to the level of the `target`, inplace.
          */
-        void mod_down_to_inplace(CKKSCiphertext &ct, const CKKSCiphertext &target);
+        void reduce_level_to_inplace(CKKSCiphertext &ct, const CKKSCiphertext &target);
 
         /* Reduce the HE level of both inputs to the lower of the two levels.
          * This can modify at most one of the inputs.
          */
-        void mod_down_to_min_inplace(CKKSCiphertext &ct1, CKKSCiphertext &ct2);
+        void reduce_level_to_min_inplace(CKKSCiphertext &ct1, CKKSCiphertext &ct2);
 
         /* Reduce the HE level of `x` to level `level`, which has
          * level+1 moduli. `level` must be >= 0.
          */
-        CKKSCiphertext mod_down_to_level(const CKKSCiphertext &ct, int level);
+        CKKSCiphertext reduce_level_to(const CKKSCiphertext &ct, int level);
 
         /* Reduce the HE level of `x` to level `level`, which has
          * level+1 moduli. `level` must be >= 0. Store the result in the first arugment.
          */
-        void mod_down_to_level_inplace(CKKSCiphertext &ct, int level);
+        void reduce_level_to_inplace(CKKSCiphertext &ct, int level);
 
         /* Remove a prime from the modulus (i.e. go down one level) and scale
          * down the plaintext by that prime.
@@ -233,7 +233,7 @@ namespace hit {
         virtual void multiply_plain_inplace_internal(CKKSCiphertext &ct, double scalar) = 0;
         virtual void multiply_plain_inplace_internal(CKKSCiphertext &ct, const std::vector<double> &plain) = 0;
         virtual void square_inplace_internal(CKKSCiphertext &ct) = 0;
-        virtual void mod_down_to_level_inplace_internal(CKKSCiphertext &ct, int level) = 0;
+        virtual void reduce_level_to_inplace_internal(CKKSCiphertext &ct, int level) = 0;
         virtual void rescale_to_next_inplace_internal(CKKSCiphertext &ct) = 0;
         virtual void relinearize_inplace_internal(CKKSCiphertext &ct) = 0;
         virtual void reset_internal() = 0;

--- a/src/hit/api/evaluator/debug.cpp
+++ b/src/hit/api/evaluator/debug.cpp
@@ -372,10 +372,10 @@ namespace hit {
         check_scale(ct);
     }
 
-    void DebugEval::mod_down_to_level_inplace_internal(CKKSCiphertext &ct, int level) {
+    void DebugEval::reduce_level_to_inplace_internal(CKKSCiphertext &ct, int level) {
         check_scale(ct);
-        homomorphic_eval->mod_down_to_level_inplace_internal(ct, level);
-        scale_estimator->mod_down_to_level_inplace_internal(ct, level);
+        homomorphic_eval->reduce_level_to_inplace_internal(ct, level);
+        scale_estimator->reduce_level_to_inplace_internal(ct, level);
 
         print_stats(ct);
         check_scale(ct);

--- a/src/hit/api/evaluator/debug.h
+++ b/src/hit/api/evaluator/debug.h
@@ -77,7 +77,7 @@ namespace hit {
 
         void square_inplace_internal(CKKSCiphertext &ct) override;
 
-        void mod_down_to_level_inplace_internal(CKKSCiphertext &ct, int level) override;
+        void reduce_level_to_inplace_internal(CKKSCiphertext &ct, int level) override;
 
         void rescale_to_next_inplace_internal(CKKSCiphertext &ct) override;
 

--- a/src/hit/api/evaluator/depthfinder.cpp
+++ b/src/hit/api/evaluator/depthfinder.cpp
@@ -112,7 +112,7 @@ namespace hit {
         print_stats(ct);
     }
 
-    void DepthFinder::mod_down_to_level_inplace_internal(CKKSCiphertext &ct, int level) {
+    void DepthFinder::reduce_level_to_inplace_internal(CKKSCiphertext &ct, int level) {
         if (ct.he_level() >= level) {
             ct.he_level_ = level;
         } else {

--- a/src/hit/api/evaluator/depthfinder.h
+++ b/src/hit/api/evaluator/depthfinder.h
@@ -66,7 +66,7 @@ namespace hit {
 
         void square_inplace_internal(CKKSCiphertext &ct) override;
 
-        void mod_down_to_level_inplace_internal(CKKSCiphertext &ct, int level) override;
+        void reduce_level_to_inplace_internal(CKKSCiphertext &ct, int level) override;
 
         void rescale_to_next_inplace_internal(CKKSCiphertext &ct) override;
 

--- a/src/hit/api/evaluator/homomorphic.cpp
+++ b/src/hit/api/evaluator/homomorphic.cpp
@@ -358,10 +358,10 @@ namespace hit {
         }
     }
 
-    void HomomorphicEval::mod_down_to_level_inplace_internal(CKKSCiphertext &ct, int level) {
+    void HomomorphicEval::reduce_level_to_inplace_internal(CKKSCiphertext &ct, int level) {
         if (get_SEAL_level(ct) < level) {
             stringstream buffer;
-            buffer << "Error in mod_down_to_level: input is at a lower level than target. Input level: "
+            buffer << "Error in reduce_level_to: input is at a lower level than target. Input level: "
                    << get_SEAL_level(ct) << ", target level: " << level;
             throw invalid_argument(buffer.str());
         }

--- a/src/hit/api/evaluator/homomorphic.h
+++ b/src/hit/api/evaluator/homomorphic.h
@@ -93,7 +93,7 @@ namespace hit {
 
         void square_inplace_internal(CKKSCiphertext &ct) override;
 
-        void mod_down_to_level_inplace_internal(CKKSCiphertext &ct, int level) override;
+        void reduce_level_to_inplace_internal(CKKSCiphertext &ct, int level) override;
 
         void rescale_to_next_inplace_internal(CKKSCiphertext &ct) override;
 

--- a/src/hit/api/evaluator/opcount.cpp
+++ b/src/hit/api/evaluator/opcount.cpp
@@ -26,8 +26,8 @@ namespace hit {
             additions_ = 0;
             negations_ = 0;
             rotations_ = 0;
-            mod_downs_ = 0;
-            mod_down_multi_levels_ = 0;
+            reduce_levels_ = 0;
+            reduce_level_muls_ = 0;
             encryptions_ = 0;
         }
         depth_finder->reset_internal();
@@ -52,11 +52,11 @@ namespace hit {
     void OpCount::print_op_count() const {
         shared_lock lock(mutex_);
         LOG(INFO) << "Multiplications: " << multiplies_;
-        LOG(INFO) << "ModDownMuls: " << mod_down_multi_levels_;
+        LOG(INFO) << "ReduceLevelMuls: " << reduce_level_muls_;
         LOG(INFO) << "Additions: " << additions_;
         LOG(INFO) << "Negations: " << negations_;
         LOG(INFO) << "Rotations: " << rotations_;
-        LOG(INFO) << "ModDownTos: " << mod_downs_;
+        LOG(INFO) << "ReduceLevels: " << reduce_levels_;
         LOG(INFO) << "Encryptions: " << encryption_count_;
     }
 
@@ -128,15 +128,15 @@ namespace hit {
         depth_finder->square_inplace_internal(ct);
     }
 
-    void OpCount::mod_down_to_level_inplace_internal(CKKSCiphertext &ct, int level) {
+    void OpCount::reduce_level_to_inplace_internal(CKKSCiphertext &ct, int level) {
         {
             scoped_lock lock(mutex_);
             if (ct.he_level() - level > 0) {
-                mod_downs_++;
+                reduce_levels_++;
             }
-            mod_down_multi_levels_ += (ct.he_level() - level);
+            reduce_level_muls_ += (ct.he_level() - level);
         }
-        depth_finder->mod_down_to_level_inplace_internal(ct, level);
+        depth_finder->reduce_level_to_inplace_internal(ct, level);
     }
 
     void OpCount::rescale_to_next_inplace_internal(CKKSCiphertext &ct) {

--- a/src/hit/api/evaluator/opcount.h
+++ b/src/hit/api/evaluator/opcount.h
@@ -56,7 +56,7 @@ namespace hit {
 
         void square_inplace_internal(CKKSCiphertext &ct) override;
 
-        void mod_down_to_level_inplace_internal(CKKSCiphertext &ct, int level) override;
+        void reduce_level_to_inplace_internal(CKKSCiphertext &ct, int level) override;
 
         void rescale_to_next_inplace_internal(CKKSCiphertext &ct) override;
 
@@ -70,8 +70,8 @@ namespace hit {
         int additions_ = 0;
         int negations_ = 0;
         int rotations_ = 0;
-        int mod_downs_ = 0;
-        int mod_down_multi_levels_ = 0;
+        int reduce_levels_ = 0;
+        int reduce_level_muls_ = 0;
         int encryptions_ = 0;
 
         inline void count_multiple_ops() {

--- a/src/hit/api/evaluator/plaintext.cpp
+++ b/src/hit/api/evaluator/plaintext.cpp
@@ -222,7 +222,7 @@ namespace hit {
         print_stats(ct);
     }
 
-    void PlaintextEval::mod_down_to_level_inplace_internal(CKKSCiphertext &ct, int) {
+    void PlaintextEval::reduce_level_to_inplace_internal(CKKSCiphertext &ct, int) {
         // does not change plaintext_max_log_
         print_stats(ct);
     }

--- a/src/hit/api/evaluator/plaintext.h
+++ b/src/hit/api/evaluator/plaintext.h
@@ -69,7 +69,7 @@ namespace hit {
 
         void square_inplace_internal(CKKSCiphertext &ct) override;
 
-        void mod_down_to_level_inplace_internal(CKKSCiphertext &ct, int level) override;
+        void reduce_level_to_inplace_internal(CKKSCiphertext &ct, int level) override;
 
         void rescale_to_next_inplace_internal(CKKSCiphertext &ct) override;
 

--- a/src/hit/api/evaluator/scaleestimator.cpp
+++ b/src/hit/api/evaluator/scaleestimator.cpp
@@ -274,15 +274,15 @@ namespace hit {
         print_stats(ct);
     }
 
-    void ScaleEstimator::mod_down_to_level_inplace_internal(CKKSCiphertext &ct, int level) {
+    void ScaleEstimator::reduce_level_to_inplace_internal(CKKSCiphertext &ct, int level) {
         int level_diff = ct.he_level() - level;
 
         if (level < 0) {
-            throw invalid_argument("modDownToLevel: level must be >= 0.");
+            throw invalid_argument("reduce_level_to: level must be >= 0.");
         }
 
-        depth_finder->mod_down_to_level_inplace_internal(ct, level);
-        plaintext_eval->mod_down_to_level_inplace_internal(ct, level);
+        depth_finder->reduce_level_to_inplace_internal(ct, level);
+        plaintext_eval->reduce_level_to_inplace_internal(ct, level);
 
         // reset he_level for dest
         ct.he_level_ += level_diff;

--- a/src/hit/api/evaluator/scaleestimator.h
+++ b/src/hit/api/evaluator/scaleestimator.h
@@ -73,7 +73,7 @@ namespace hit {
 
         void square_inplace_internal(CKKSCiphertext &ct) override;
 
-        void mod_down_to_level_inplace_internal(CKKSCiphertext &ct, int level) override;
+        void reduce_level_to_inplace_internal(CKKSCiphertext &ct, int level) override;
 
         void rescale_to_next_inplace_internal(CKKSCiphertext &ct) override;
 

--- a/src/hit/api/linearalgebra/linearalgebra.cpp
+++ b/src/hit/api/linearalgebra/linearalgebra.cpp
@@ -130,9 +130,9 @@ namespace hit {
     template EncryptedMatrix LinearAlgebra::add(const EncryptedMatrix &, double);
     template void LinearAlgebra::add_inplace(EncryptedMatrix &enc_mat, double scalar);
     template EncryptedMatrix LinearAlgebra::multiply(const EncryptedMatrix &, double);
-    template void LinearAlgebra::mod_down_to_min_inplace(EncryptedMatrix &, EncryptedMatrix &);
-    template EncryptedMatrix LinearAlgebra::mod_down_to_level(const EncryptedMatrix &, int);
-    template void LinearAlgebra::mod_down_to_level_inplace(EncryptedMatrix &, int);
+    template void LinearAlgebra::reduce_level_to_min_inplace(EncryptedMatrix &, EncryptedMatrix &);
+    template EncryptedMatrix LinearAlgebra::reduce_level_to(const EncryptedMatrix &, int);
+    template void LinearAlgebra::reduce_level_to_inplace(EncryptedMatrix &, int);
     template void LinearAlgebra::rescale_to_next_inplace(EncryptedMatrix &);
     template EncryptedMatrix LinearAlgebra::rescale_to_next(const EncryptedMatrix &);
     template void LinearAlgebra::relinearize_inplace(EncryptedMatrix &);
@@ -140,12 +140,12 @@ namespace hit {
     template EncryptedMatrix LinearAlgebra::hadamard_square(const EncryptedMatrix &);
     template EncryptedMatrix LinearAlgebra::hadamard_multiply(const EncryptedMatrix &, const EncryptedMatrix &);
     template void LinearAlgebra::hadamard_multiply_inplace(EncryptedMatrix &, const EncryptedMatrix &);
-    template EncryptedMatrix LinearAlgebra::mod_down_to(const EncryptedMatrix &, const EncryptedMatrix &);
-    template EncryptedMatrix LinearAlgebra::mod_down_to(const EncryptedMatrix &, const EncryptedRowVector &);
-    template EncryptedMatrix LinearAlgebra::mod_down_to(const EncryptedMatrix &, const EncryptedColVector &);
-    template void LinearAlgebra::mod_down_to_inplace(EncryptedMatrix &, const EncryptedMatrix &);
-    template void LinearAlgebra::mod_down_to_inplace(EncryptedMatrix &, const EncryptedRowVector &);
-    template void LinearAlgebra::mod_down_to_inplace(EncryptedMatrix &, const EncryptedColVector &);
+    template EncryptedMatrix LinearAlgebra::reduce_level_to(const EncryptedMatrix &, const EncryptedMatrix &);
+    template EncryptedMatrix LinearAlgebra::reduce_level_to(const EncryptedMatrix &, const EncryptedRowVector &);
+    template EncryptedMatrix LinearAlgebra::reduce_level_to(const EncryptedMatrix &, const EncryptedColVector &);
+    template void LinearAlgebra::reduce_level_to_inplace(EncryptedMatrix &, const EncryptedMatrix &);
+    template void LinearAlgebra::reduce_level_to_inplace(EncryptedMatrix &, const EncryptedRowVector &);
+    template void LinearAlgebra::reduce_level_to_inplace(EncryptedMatrix &, const EncryptedColVector &);
 
     // explicit template instantiation
     template EncryptedRowVector LinearAlgebra::add(const EncryptedRowVector &, const EncryptedRowVector &);
@@ -155,9 +155,9 @@ namespace hit {
     template EncryptedRowVector LinearAlgebra::add(const EncryptedRowVector &, double);
     template void LinearAlgebra::add_inplace(EncryptedRowVector &enc_vec, double scalar);
     template EncryptedRowVector LinearAlgebra::multiply(const EncryptedRowVector &, double);
-    template void LinearAlgebra::mod_down_to_min_inplace(EncryptedRowVector &, EncryptedRowVector &);
-    template EncryptedRowVector LinearAlgebra::mod_down_to_level(const EncryptedRowVector &, int);
-    template void LinearAlgebra::mod_down_to_level_inplace(EncryptedRowVector &, int);
+    template void LinearAlgebra::reduce_level_to_min_inplace(EncryptedRowVector &, EncryptedRowVector &);
+    template EncryptedRowVector LinearAlgebra::reduce_level_to(const EncryptedRowVector &, int);
+    template void LinearAlgebra::reduce_level_to_inplace(EncryptedRowVector &, int);
     template void LinearAlgebra::rescale_to_next_inplace(EncryptedRowVector &);
     template EncryptedRowVector LinearAlgebra::rescale_to_next(const EncryptedRowVector &);
     template void LinearAlgebra::relinearize_inplace(EncryptedRowVector &);
@@ -166,12 +166,12 @@ namespace hit {
     template EncryptedRowVector LinearAlgebra::hadamard_multiply(const EncryptedRowVector &,
                                                                  const EncryptedRowVector &);
     template void LinearAlgebra::hadamard_multiply_inplace(EncryptedRowVector &, const EncryptedRowVector &);
-    template EncryptedRowVector LinearAlgebra::mod_down_to(const EncryptedRowVector &, const EncryptedMatrix &);
-    template EncryptedRowVector LinearAlgebra::mod_down_to(const EncryptedRowVector &, const EncryptedRowVector &);
-    template EncryptedRowVector LinearAlgebra::mod_down_to(const EncryptedRowVector &, const EncryptedColVector &);
-    template void LinearAlgebra::mod_down_to_inplace(EncryptedRowVector &, const EncryptedMatrix &);
-    template void LinearAlgebra::mod_down_to_inplace(EncryptedRowVector &, const EncryptedRowVector &);
-    template void LinearAlgebra::mod_down_to_inplace(EncryptedRowVector &, const EncryptedColVector &);
+    template EncryptedRowVector LinearAlgebra::reduce_level_to(const EncryptedRowVector &, const EncryptedMatrix &);
+    template EncryptedRowVector LinearAlgebra::reduce_level_to(const EncryptedRowVector &, const EncryptedRowVector &);
+    template EncryptedRowVector LinearAlgebra::reduce_level_to(const EncryptedRowVector &, const EncryptedColVector &);
+    template void LinearAlgebra::reduce_level_to_inplace(EncryptedRowVector &, const EncryptedMatrix &);
+    template void LinearAlgebra::reduce_level_to_inplace(EncryptedRowVector &, const EncryptedRowVector &);
+    template void LinearAlgebra::reduce_level_to_inplace(EncryptedRowVector &, const EncryptedColVector &);
 
     // explicit template instantiation
     template EncryptedColVector LinearAlgebra::add(const EncryptedColVector &, const EncryptedColVector &);
@@ -181,9 +181,9 @@ namespace hit {
     template EncryptedColVector LinearAlgebra::add(const EncryptedColVector &, double);
     template void LinearAlgebra::add_inplace(EncryptedColVector &enc_vec, double scalar);
     template EncryptedColVector LinearAlgebra::multiply(const EncryptedColVector &, double);
-    template void LinearAlgebra::mod_down_to_min_inplace(EncryptedColVector &, EncryptedColVector &);
-    template EncryptedColVector LinearAlgebra::mod_down_to_level(const EncryptedColVector &, int);
-    template void LinearAlgebra::mod_down_to_level_inplace(EncryptedColVector &, int);
+    template void LinearAlgebra::reduce_level_to_min_inplace(EncryptedColVector &, EncryptedColVector &);
+    template EncryptedColVector LinearAlgebra::reduce_level_to(const EncryptedColVector &, int);
+    template void LinearAlgebra::reduce_level_to_inplace(EncryptedColVector &, int);
     template void LinearAlgebra::rescale_to_next_inplace(EncryptedColVector &);
     template EncryptedColVector LinearAlgebra::rescale_to_next(const EncryptedColVector &);
     template void LinearAlgebra::relinearize_inplace(EncryptedColVector &);
@@ -192,12 +192,12 @@ namespace hit {
     template EncryptedColVector LinearAlgebra::hadamard_multiply(const EncryptedColVector &,
                                                                  const EncryptedColVector &);
     template void LinearAlgebra::hadamard_multiply_inplace(EncryptedColVector &, const EncryptedColVector &);
-    template EncryptedColVector LinearAlgebra::mod_down_to(const EncryptedColVector &, const EncryptedMatrix &);
-    template EncryptedColVector LinearAlgebra::mod_down_to(const EncryptedColVector &, const EncryptedRowVector &);
-    template EncryptedColVector LinearAlgebra::mod_down_to(const EncryptedColVector &, const EncryptedColVector &);
-    template void LinearAlgebra::mod_down_to_inplace(EncryptedColVector &, const EncryptedMatrix &);
-    template void LinearAlgebra::mod_down_to_inplace(EncryptedColVector &, const EncryptedRowVector &);
-    template void LinearAlgebra::mod_down_to_inplace(EncryptedColVector &, const EncryptedColVector &);
+    template EncryptedColVector LinearAlgebra::reduce_level_to(const EncryptedColVector &, const EncryptedMatrix &);
+    template EncryptedColVector LinearAlgebra::reduce_level_to(const EncryptedColVector &, const EncryptedRowVector &);
+    template EncryptedColVector LinearAlgebra::reduce_level_to(const EncryptedColVector &, const EncryptedColVector &);
+    template void LinearAlgebra::reduce_level_to_inplace(EncryptedColVector &, const EncryptedMatrix &);
+    template void LinearAlgebra::reduce_level_to_inplace(EncryptedColVector &, const EncryptedRowVector &);
+    template void LinearAlgebra::reduce_level_to_inplace(EncryptedColVector &, const EncryptedColVector &);
 
     void LinearAlgebra::add_inplace(EncryptedMatrix &enc_mat1, const Matrix &mat2) {
         if (!enc_mat1.initialized() || enc_mat1.height() != mat2.size1() || enc_mat1.width() != mat2.size2()) {
@@ -433,7 +433,7 @@ namespace hit {
         EncryptedMatrix mat_b_leveled = enc_mat_b;
         for (int i = 0; i < enc_mat_b.cts.size(); i++) {
             for (int j = 0; j < enc_mat_b.cts[0].size(); j++) {
-                eval.mod_down_to_level_inplace(mat_b_leveled.cts[i][j], enc_mat_a_trans.he_level() - 1);
+                eval.reduce_level_to_inplace(mat_b_leveled.cts[i][j], enc_mat_a_trans.he_level() - 1);
             }
         }
 

--- a/src/hit/api/linearalgebra/linearalgebra.h
+++ b/src/hit/api/linearalgebra/linearalgebra.h
@@ -401,8 +401,8 @@ namespace hit {
          * a linear ciphertext which does not need to be rescaled.
          */
         template <typename T1, typename T2>
-        T1 mod_down_to(const T1 &arg1, const T2 &arg2) {
-            return mod_down_to_level(arg1, arg2.he_level());
+        T1 reduce_level_to(const T1 &arg1, const T2 &arg2) {
+            return reduce_level_to(arg1, arg2.he_level());
         }
 
         /* Reduce the HE level of the first argument to level of the second argument, inplace.
@@ -423,8 +423,8 @@ namespace hit {
          * a linear ciphertext which does not need to be rescaled.
          */
         template <typename T1, typename T2>
-        void mod_down_to_inplace(T1 &arg1, const T2 &arg2) {
-            mod_down_to_level_inplace(arg1, arg2.he_level());
+        void reduce_level_to_inplace(T1 &arg1, const T2 &arg2) {
+            reduce_level_to_inplace(arg1, arg2.he_level());
         }
 
         /* Reduce the HE level of both inputs to the lower of the two levels. This can modify at most one of the inputs.
@@ -439,13 +439,13 @@ namespace hit {
          * a linear ciphertext which does not need to be rescaled.
          */
         template <typename T>
-        void mod_down_to_min_inplace(T &arg1, T &arg2) {
+        void reduce_level_to_min_inplace(T &arg1, T &arg2) {
             if (!arg1.initialized() || !arg2.initialized()) {
-                throw std::invalid_argument("LinearAlgebra::mod_down_to_min: arguments not initialized.");
+                throw std::invalid_argument("LinearAlgebra::reduce_level_to_min: arguments not initialized.");
             }
 
             for (size_t i = 0; i < arg1.num_cts(); i++) {
-                eval.mod_down_to_min_inplace(arg1[i], arg2[i]);
+                eval.reduce_level_to_min_inplace(arg1[i], arg2[i]);
             }
         }
 
@@ -461,9 +461,9 @@ namespace hit {
          * a linear ciphertext which does not need to be rescaled.
          */
         template <typename T>
-        T mod_down_to_level(const T &arg, int level) {
+        T reduce_level_to(const T &arg, int level) {
             T temp = arg;
-            mod_down_to_level_inplace(temp, level);
+            reduce_level_to_inplace(temp, level);
             return temp;
         }
 
@@ -479,13 +479,13 @@ namespace hit {
          * a linear ciphertext which does not need to be rescaled.
          */
         template <typename T>
-        void mod_down_to_level_inplace(T &arg, int level) {
+        void reduce_level_to_inplace(T &arg, int level) {
             if (!arg.initialized()) {
-                throw std::invalid_argument("LinearAlgebra::mod_down_to_level: argument not initialized.");
+                throw std::invalid_argument("LinearAlgebra::reduce_level_to: argument not initialized.");
             }
 
             for (size_t i = 0; i < arg.num_cts(); i++) {
-                eval.mod_down_to_level_inplace(arg[i], level);
+                eval.reduce_level_to_inplace(arg[i], level);
             }
         }
 
@@ -520,7 +520,7 @@ namespace hit {
         template <typename T>
         void rescale_to_next_inplace(T &arg) {
             if (!arg.initialized()) {
-                throw std::invalid_argument("LinearAlgebra::mod_down_to_level: argument not initialized.");
+                throw std::invalid_argument("LinearAlgebra::reduce_level_to: argument not initialized.");
             }
 
             for (size_t i = 0; i < arg.num_cts(); i++) {
@@ -551,7 +551,7 @@ namespace hit {
         template <typename T>
         void relinearize_inplace(T &arg) {
             if (!arg.initialized()) {
-                throw std::invalid_argument("LinearAlgebra::mod_down_to_level: argument not initialized.");
+                throw std::invalid_argument("LinearAlgebra::reduce_level_to: argument not initialized.");
             }
 
             for (size_t i = 0; i < arg.num_cts(); i++) {

--- a/tests/api/evaluator/depthfinder.cpp
+++ b/tests/api/evaluator/depthfinder.cpp
@@ -114,7 +114,7 @@ TEST(DepthFinderTest, AddCiphertextWithDiffHeLevel) {
     CKKSCiphertext ciphertext1, ciphertext2;
     ciphertext1 = ckks_instance.encrypt(VECTOR_1);
     ciphertext2 = ckks_instance.encrypt(VECTOR_1);
-    ckks_instance.mod_down_to_level_inplace(ciphertext2, ciphertext2.he_level() - 1);
+    ckks_instance.reduce_level_to_inplace(ciphertext2, ciphertext2.he_level() - 1);
     ASSERT_THROW((
                      // Expect invalid_argument is thrown because he_level of the two ciphertexts is different.
                      ckks_instance.add(ciphertext1, ciphertext2)),
@@ -157,7 +157,7 @@ TEST(DepthFinderTest, Multiply_InvalidCase) {
     CKKSCiphertext ciphertext1, ciphertext2;
     ciphertext1 = ckks_instance.encrypt(VECTOR_1);
     ciphertext2 = ckks_instance.encrypt(VECTOR_1);
-    ckks_instance.mod_down_to_level_inplace(ciphertext2, ciphertext2.he_level() - 1);
+    ckks_instance.reduce_level_to_inplace(ciphertext2, ciphertext2.he_level() - 1);
     ASSERT_THROW((
                      // Expect invalid_argument is thrown because he_level of the two ciphertexts is different.
                      ckks_instance.multiply(ciphertext1, ciphertext2)),
@@ -174,40 +174,40 @@ TEST(DepthFinderTest, Square) {
     ASSERT_EQ(0, ckks_instance.get_multiplicative_depth());
 }
 
-TEST(DepthFinderTest, ModDownToMin) {
+TEST(DepthFinderTest, ReduceLevelToMin) {
     DepthFinder ckks_instance = DepthFinder();
     CKKSCiphertext ciphertext1, ciphertext2, ciphertext3;
     ciphertext1 = ckks_instance.encrypt(VECTOR_1);
     ciphertext2 = ckks_instance.encrypt(VECTOR_1);
     ciphertext3 = ckks_instance.encrypt(VECTOR_1);
-    ckks_instance.mod_down_to_level_inplace(ciphertext3, ciphertext3.he_level() - 1);
-    ckks_instance.mod_down_to_min_inplace(ciphertext1, ciphertext3);
-    ckks_instance.mod_down_to_min_inplace(ciphertext3, ciphertext2);
+    ckks_instance.reduce_level_to_inplace(ciphertext3, ciphertext3.he_level() - 1);
+    ckks_instance.reduce_level_to_min_inplace(ciphertext1, ciphertext3);
+    ckks_instance.reduce_level_to_min_inplace(ciphertext3, ciphertext2);
     // Expect he_level is changed.
     ASSERT_EQ(ciphertext3.he_level(), ciphertext2.he_level());
     ASSERT_EQ(ciphertext3.he_level(), ciphertext1.he_level());
     ASSERT_EQ(0, ckks_instance.get_multiplicative_depth());
 }
 
-TEST(DepthFinderTest, ModDownToLevel) {
+TEST(DepthFinderTest, ReduceLevelTo) {
     DepthFinder ckks_instance = DepthFinder();
     CKKSCiphertext ciphertext1, ciphertext2;
     ciphertext1 = ckks_instance.encrypt(VECTOR_1);
     int he_level = ciphertext1.he_level();
-    ciphertext2 = ckks_instance.mod_down_to_level(ciphertext1, he_level - 1);
+    ciphertext2 = ckks_instance.reduce_level_to(ciphertext1, he_level - 1);
     // Expect he_level is changed.
     ASSERT_EQ(he_level - 1, ciphertext2.he_level());
     ASSERT_EQ(0, ckks_instance.get_multiplicative_depth());
 }
 
-TEST(DepthFinderTest, ModDownToLevel_InvalidCase) {
+TEST(DepthFinderTest, ReduceLevelTo_InvalidCase) {
     DepthFinder ckks_instance = DepthFinder();
     CKKSCiphertext ciphertext1;
     ciphertext1 = ckks_instance.encrypt(VECTOR_1);
     int he_level = ciphertext1.he_level();
     ASSERT_THROW((
                      // Expect invalid_argument is thrown when cipherText is mod to higher level.
-                     ckks_instance.mod_down_to_level(ciphertext1, he_level + 1)),
+                     ckks_instance.reduce_level_to(ciphertext1, he_level + 1)),
                  invalid_argument);
 }
 

--- a/tests/api/evaluator/homomorphic.cpp
+++ b/tests/api/evaluator/homomorphic.cpp
@@ -317,12 +317,12 @@ TEST(HomomorphicTest, Square) {
     ASSERT_LE(diff, MAX_NORM);
 }
 
-TEST(HomomorphicTest, ModDownToLevel) {
+TEST(HomomorphicTest, ReduceLevelTo) {
     HomomorphicEval ckks_instance = HomomorphicEval(NUM_OF_SLOTS, ONE_MULTI_DEPTH, LOG_SCALE);
     CKKSCiphertext ciphertext1, ciphertext2;
     vector<double> vector1 = random_vector(NUM_OF_SLOTS, RANGE);
     ciphertext1 = ckks_instance.encrypt(vector1);
-    ciphertext2 = ckks_instance.mod_down_to_level(ciphertext1, ZERO_MULTI_DEPTH);
+    ciphertext2 = ckks_instance.reduce_level_to(ciphertext1, ZERO_MULTI_DEPTH);
     // Check scale and he_level.
     ASSERT_EQ(ciphertext2.he_level(), ZERO_MULTI_DEPTH);
     uint64_t prime = get_last_prime(ckks_instance.context, ONE_MULTI_DEPTH);
@@ -334,25 +334,25 @@ TEST(HomomorphicTest, ModDownToLevel) {
     ASSERT_LE(diff, MAX_NORM);
 }
 
-TEST(HomomorphicTest, ModDownToLevel_InvalidCase) {
+TEST(HomomorphicTest, ReduceLevelTo_InvalidCase) {
     HomomorphicEval ckks_instance = HomomorphicEval(NUM_OF_SLOTS, ZERO_MULTI_DEPTH, LOG_SCALE);
     CKKSCiphertext ciphertext1;
     ciphertext1 = ckks_instance.encrypt(VECTOR_1);
     ASSERT_THROW((
                      // Expect invalid_argument is thrown when the level is higher.
-                     ckks_instance.mod_down_to_level(ciphertext1, ONE_MULTI_DEPTH)),
+                     ckks_instance.reduce_level_to(ciphertext1, ONE_MULTI_DEPTH)),
                  invalid_argument);
 }
 
-TEST(HomomorphicTest, ModDownToMin) {
+TEST(HomomorphicTest, ReduceLevelToMin) {
     HomomorphicEval ckks_instance = HomomorphicEval(NUM_OF_SLOTS, ONE_MULTI_DEPTH, LOG_SCALE);
     CKKSCiphertext ciphertext1, ciphertext2, ciphertext3;
     vector<double> vector1 = random_vector(NUM_OF_SLOTS, RANGE);
     ciphertext1 = ckks_instance.encrypt(vector1);
     ciphertext3 = ciphertext1;
-    ciphertext2 = ckks_instance.mod_down_to_level(ciphertext1, ZERO_MULTI_DEPTH);
-    ckks_instance.mod_down_to_min_inplace(ciphertext1, ciphertext2);
-    ckks_instance.mod_down_to_min_inplace(ciphertext2, ciphertext3);
+    ciphertext2 = ckks_instance.reduce_level_to(ciphertext1, ZERO_MULTI_DEPTH);
+    ckks_instance.reduce_level_to_min_inplace(ciphertext1, ciphertext2);
+    ckks_instance.reduce_level_to_min_inplace(ciphertext2, ciphertext3);
     // Check scale and he_level.
     ASSERT_EQ(ciphertext3.he_level(), ZERO_MULTI_DEPTH);
     uint64_t prime = get_last_prime(ckks_instance.context, ONE_MULTI_DEPTH);

--- a/tests/api/evaluator/scaleestimator.cpp
+++ b/tests/api/evaluator/scaleestimator.cpp
@@ -198,12 +198,12 @@ TEST(ScaleEstimatorTest, Square) {
     ASSERT_EQ(pow(2, DEFAULT_LOG_SCALE * 2), ciphertext2.scale());
 }
 
-TEST(ScaleEstimatorTest, ModDownToLevel) {
+TEST(ScaleEstimatorTest, ReduceLevelTo) {
     ScaleEstimator ckks_instance = ScaleEstimator(NUM_OF_SLOTS, ONE_MULTI_DEPTH);
     CKKSCiphertext ciphertext1, ciphertext2;
     ciphertext1 = ckks_instance.encrypt(VECTOR_1);
     uint64_t prime = get_last_prime(ckks_instance.context, ciphertext1.he_level());
-    ciphertext2 = ckks_instance.mod_down_to_level(ciphertext1, ZERO_MULTI_DEPTH);
+    ciphertext2 = ckks_instance.reduce_level_to(ciphertext1, ZERO_MULTI_DEPTH);
     // Check estimatedMaxLogScale.
     double estimatedMaxLogScale = PLAINTEXT_LOG_MAX - log2(VALUE);
     ASSERT_EQ(estimatedMaxLogScale, ckks_instance.get_estimated_max_log_scale());
@@ -214,26 +214,26 @@ TEST(ScaleEstimatorTest, ModDownToLevel) {
 }
 
 // TODO: investigate why previous impl can still pass this test.
-TEST(ScaleEstimatorTest, ModDownToLevel_MultiDepthIsTwo) {
+TEST(ScaleEstimatorTest, ReduceLevelTo_MultiDepthIsTwo) {
     ScaleEstimator ckks_instance = ScaleEstimator(NUM_OF_SLOTS, TWO_MULTI_DEPTH);
     CKKSCiphertext ciphertext1, ciphertext2, ciphertext3;
     ciphertext1 = ckks_instance.encrypt(VECTOR_1, TWO_MULTI_DEPTH);
     ciphertext3 = ckks_instance.encrypt(VECTOR_1, ZERO_MULTI_DEPTH);
-    ciphertext2 = ckks_instance.mod_down_to_level(ciphertext1, ZERO_MULTI_DEPTH);
+    ciphertext2 = ckks_instance.reduce_level_to(ciphertext1, ZERO_MULTI_DEPTH);
     // Expect he_level is decreased.
     ASSERT_EQ(ZERO_MULTI_DEPTH, ciphertext2.he_level());
     // Check scale.
     ASSERT_EQ(ciphertext3.scale(), ciphertext2.scale());
 }
 
-TEST(ScaleEstimatorTest, ModDownToMin) {
+TEST(ScaleEstimatorTest, ReduceLevelToMin) {
     ScaleEstimator ckks_instance = ScaleEstimator(NUM_OF_SLOTS, ONE_MULTI_DEPTH);
     CKKSCiphertext ciphertext1, ciphertext2, ciphertext3;
     ciphertext1 = ckks_instance.encrypt(VECTOR_1);
     ciphertext3 = ciphertext1;
     uint64_t prime = get_last_prime(ckks_instance.context, ciphertext1.he_level());
-    ciphertext2 = ckks_instance.mod_down_to_level(ciphertext1, ZERO_MULTI_DEPTH);
-    ckks_instance.mod_down_to_min_inplace(ciphertext1, ciphertext2);
+    ciphertext2 = ckks_instance.reduce_level_to(ciphertext1, ZERO_MULTI_DEPTH);
+    ckks_instance.reduce_level_to_min_inplace(ciphertext1, ciphertext2);
     // Check estimatedMaxLogScale.
     double estimatedMaxLogScale = PLAINTEXT_LOG_MAX - log2(VALUE);
     ASSERT_EQ(estimatedMaxLogScale, ckks_instance.get_estimated_max_log_scale());
@@ -241,8 +241,8 @@ TEST(ScaleEstimatorTest, ModDownToMin) {
     ASSERT_EQ(ZERO_MULTI_DEPTH, ciphertext1.he_level());
     // Check scale.
     ASSERT_EQ(pow(2, DEFAULT_LOG_SCALE * 2) / prime, ciphertext1.scale());
-    // Test mod_down_to_min_inplace symmetric.
-    ckks_instance.mod_down_to_min_inplace(ciphertext2, ciphertext3);
+    // Test reduce_level_to_min_inplace symmetric.
+    ckks_instance.reduce_level_to_min_inplace(ciphertext2, ciphertext3);
     // Check estimatedMaxLogScale.
     ASSERT_EQ(estimatedMaxLogScale, ckks_instance.get_estimated_max_log_scale());
     // Expect he_level is decreased.

--- a/tests/api/linearalgebra/linearalgebra.cpp
+++ b/tests/api/linearalgebra/linearalgebra.cpp
@@ -858,7 +858,7 @@ TEST(LinearAlgebraTest, MultiplyMatrixCol) {
     test_multiply_matrix_col(linear_algebra, 300, 27, PI, unit1);
 }
 
-TEST(LinearAlgebraTest, ModDownToMinMatrix) {
+TEST(LinearAlgebraTest, ReduceLevelToMinMatrix) {
     HomomorphicEval ckks_instance = HomomorphicEval(NUM_OF_SLOTS, ONE_MULTI_DEPTH, LOG_SCALE);
     LinearAlgebra linear_algebra = LinearAlgebra(ckks_instance);
 
@@ -870,17 +870,17 @@ TEST(LinearAlgebraTest, ModDownToMinMatrix) {
     EncryptedMatrix ct_mat0 = linear_algebra.encrypt_matrix(mat, unit1, 0);
     ASSERT_EQ(ct_mat1.he_level(), 1);
     ASSERT_EQ(ct_mat0.he_level(), 0);
-    linear_algebra.mod_down_to_min_inplace(ct_mat1, ct_mat0);
+    linear_algebra.reduce_level_to_min_inplace(ct_mat1, ct_mat0);
     ASSERT_EQ(ct_mat1.he_level(), 0);
 
     ct_mat1 = linear_algebra.encrypt_matrix(mat, unit1);
     ASSERT_EQ(ct_mat1.he_level(), 1);
     ASSERT_EQ(ct_mat0.he_level(), 0);
-    linear_algebra.mod_down_to_min_inplace(ct_mat0, ct_mat1);
+    linear_algebra.reduce_level_to_min_inplace(ct_mat0, ct_mat1);
     ASSERT_EQ(ct_mat1.he_level(), 0);
 }
 
-TEST(LinearAlgebraTest, ModDownToMinRow) {
+TEST(LinearAlgebraTest, ReduceLevelToMinRow) {
     HomomorphicEval ckks_instance = HomomorphicEval(NUM_OF_SLOTS, ONE_MULTI_DEPTH, LOG_SCALE);
     LinearAlgebra linear_algebra = LinearAlgebra(ckks_instance);
 
@@ -892,17 +892,17 @@ TEST(LinearAlgebraTest, ModDownToMinRow) {
     EncryptedRowVector ct_vec0 = linear_algebra.encrypt_row_vector(vec, unit1, 0);
     ASSERT_EQ(ct_vec1.he_level(), 1);
     ASSERT_EQ(ct_vec0.he_level(), 0);
-    linear_algebra.mod_down_to_min_inplace(ct_vec1, ct_vec0);
+    linear_algebra.reduce_level_to_min_inplace(ct_vec1, ct_vec0);
     ASSERT_EQ(ct_vec1.he_level(), 0);
 
     ct_vec1 = linear_algebra.encrypt_row_vector(vec, unit1);
     ASSERT_EQ(ct_vec1.he_level(), 1);
     ASSERT_EQ(ct_vec0.he_level(), 0);
-    linear_algebra.mod_down_to_min_inplace(ct_vec0, ct_vec1);
+    linear_algebra.reduce_level_to_min_inplace(ct_vec0, ct_vec1);
     ASSERT_EQ(ct_vec1.he_level(), 0);
 }
 
-TEST(LinearAlgebraTest, ModDownToMinCol) {
+TEST(LinearAlgebraTest, ReduceLevelToMinCol) {
     HomomorphicEval ckks_instance = HomomorphicEval(NUM_OF_SLOTS, ONE_MULTI_DEPTH, LOG_SCALE);
     LinearAlgebra linear_algebra = LinearAlgebra(ckks_instance);
 
@@ -914,17 +914,17 @@ TEST(LinearAlgebraTest, ModDownToMinCol) {
     EncryptedColVector ct_vec0 = linear_algebra.encrypt_col_vector(vec, unit1, 0);
     ASSERT_EQ(ct_vec1.he_level(), 1);
     ASSERT_EQ(ct_vec0.he_level(), 0);
-    linear_algebra.mod_down_to_min_inplace(ct_vec1, ct_vec0);
+    linear_algebra.reduce_level_to_min_inplace(ct_vec1, ct_vec0);
     ASSERT_EQ(ct_vec1.he_level(), 0);
 
     ct_vec1 = linear_algebra.encrypt_col_vector(vec, unit1);
     ASSERT_EQ(ct_vec1.he_level(), 1);
     ASSERT_EQ(ct_vec0.he_level(), 0);
-    linear_algebra.mod_down_to_min_inplace(ct_vec0, ct_vec1);
+    linear_algebra.reduce_level_to_min_inplace(ct_vec0, ct_vec1);
     ASSERT_EQ(ct_vec1.he_level(), 0);
 }
 
-TEST(LinearAlgebraTest, ModDownToLevelMatrix) {
+TEST(LinearAlgebraTest, ReduceLevelToMatrix) {
     HomomorphicEval ckks_instance = HomomorphicEval(NUM_OF_SLOTS, ONE_MULTI_DEPTH, LOG_SCALE);
     LinearAlgebra linear_algebra = LinearAlgebra(ckks_instance);
 
@@ -934,11 +934,11 @@ TEST(LinearAlgebraTest, ModDownToLevelMatrix) {
     Matrix mat = random_mat(64, 64);
     EncryptedMatrix ct_mat1 = linear_algebra.encrypt_matrix(mat, unit1);
     ASSERT_EQ(ct_mat1.he_level(), 1);
-    linear_algebra.mod_down_to_level_inplace(ct_mat1, 0);
+    linear_algebra.reduce_level_to_inplace(ct_mat1, 0);
     ASSERT_EQ(ct_mat1.he_level(), 0);
 }
 
-TEST(LinearAlgebraTest, ModDownToLevelRow) {
+TEST(LinearAlgebraTest, ReduceLevelToRow) {
     HomomorphicEval ckks_instance = HomomorphicEval(NUM_OF_SLOTS, ONE_MULTI_DEPTH, LOG_SCALE);
     LinearAlgebra linear_algebra = LinearAlgebra(ckks_instance);
 
@@ -948,11 +948,11 @@ TEST(LinearAlgebraTest, ModDownToLevelRow) {
     Vector vec = random_vec(64);
     EncryptedRowVector ct_vec1 = linear_algebra.encrypt_row_vector(vec, unit1);
     ASSERT_EQ(ct_vec1.he_level(), 1);
-    linear_algebra.mod_down_to_level_inplace(ct_vec1, 0);
+    linear_algebra.reduce_level_to_inplace(ct_vec1, 0);
     ASSERT_EQ(ct_vec1.he_level(), 0);
 }
 
-TEST(LinearAlgebraTest, ModDownToLevelCol) {
+TEST(LinearAlgebraTest, ReduceLevelToCol) {
     HomomorphicEval ckks_instance = HomomorphicEval(NUM_OF_SLOTS, ONE_MULTI_DEPTH, LOG_SCALE);
     LinearAlgebra linear_algebra = LinearAlgebra(ckks_instance);
 
@@ -962,7 +962,7 @@ TEST(LinearAlgebraTest, ModDownToLevelCol) {
     Vector vec = random_vec(64);
     EncryptedColVector ct_vec1 = linear_algebra.encrypt_col_vector(vec, unit1);
     ASSERT_EQ(ct_vec1.he_level(), 1);
-    linear_algebra.mod_down_to_level_inplace(ct_vec1, 0);
+    linear_algebra.reduce_level_to_inplace(ct_vec1, 0);
     ASSERT_EQ(ct_vec1.he_level(), 0);
 }
 
@@ -1341,7 +1341,7 @@ TEST(LinearAlgebraTest, HadamardMulColSquare) {
     test_hadamard_mul_col_square(linear_algebra, 128, unit1);
 }
 
-TEST(LinearAlgebraTest, ModDownToMin_Matrix) {
+TEST(LinearAlgebraTest, ReduceLevelToMin_Matrix) {
     HomomorphicEval ckks_instance = HomomorphicEval(NUM_OF_SLOTS, ONE_MULTI_DEPTH, LOG_SCALE);
     LinearAlgebra linear_algebra = LinearAlgebra(ckks_instance);
 
@@ -1352,15 +1352,15 @@ TEST(LinearAlgebraTest, ModDownToMin_Matrix) {
 
     EncryptedMatrix ct_mat1 = linear_algebra.encrypt_matrix(mat1, unit);
     EncryptedMatrix ct_mat2 = linear_algebra.encrypt_matrix(mat1, unit, 0);
-    linear_algebra.mod_down_to_min_inplace(ct_mat1, ct_mat2);
+    linear_algebra.reduce_level_to_min_inplace(ct_mat1, ct_mat2);
     ASSERT_EQ(ct_mat1.he_level(), 0);
 
     EncryptedMatrix ct_vec3 = linear_algebra.encrypt_matrix(mat1, unit);
-    linear_algebra.mod_down_to_min_inplace(ct_mat2, ct_vec3);
+    linear_algebra.reduce_level_to_min_inplace(ct_mat2, ct_vec3);
     ASSERT_EQ(ct_vec3.he_level(), 0);
 }
 
-TEST(LinearAlgebraTest, ModDownToMin_ColVec) {
+TEST(LinearAlgebraTest, ReduceLevelToMin_ColVec) {
     HomomorphicEval ckks_instance = HomomorphicEval(NUM_OF_SLOTS, ONE_MULTI_DEPTH, LOG_SCALE);
     LinearAlgebra linear_algebra = LinearAlgebra(ckks_instance);
 
@@ -1371,15 +1371,15 @@ TEST(LinearAlgebraTest, ModDownToMin_ColVec) {
 
     EncryptedColVector ct_vec1 = linear_algebra.encrypt_col_vector(vec1, unit);
     EncryptedColVector ct_vec2 = linear_algebra.encrypt_col_vector(vec1, unit, 0);
-    linear_algebra.mod_down_to_min_inplace(ct_vec1, ct_vec2);
+    linear_algebra.reduce_level_to_min_inplace(ct_vec1, ct_vec2);
     ASSERT_EQ(ct_vec1.he_level(), 0);
 
     EncryptedColVector ct_vec3 = linear_algebra.encrypt_col_vector(vec1, unit);
-    linear_algebra.mod_down_to_min_inplace(ct_vec2, ct_vec3);
+    linear_algebra.reduce_level_to_min_inplace(ct_vec2, ct_vec3);
     ASSERT_EQ(ct_vec3.he_level(), 0);
 }
 
-TEST(LinearAlgebraTest, ModDownToMin_RowVec) {
+TEST(LinearAlgebraTest, ReduceLevelToMin_RowVec) {
     HomomorphicEval ckks_instance = HomomorphicEval(NUM_OF_SLOTS, ONE_MULTI_DEPTH, LOG_SCALE);
     LinearAlgebra linear_algebra = LinearAlgebra(ckks_instance);
 
@@ -1390,15 +1390,15 @@ TEST(LinearAlgebraTest, ModDownToMin_RowVec) {
 
     EncryptedRowVector ct_vec1 = linear_algebra.encrypt_row_vector(vec1, unit);
     EncryptedRowVector ct_vec2 = linear_algebra.encrypt_row_vector(vec1, unit, 0);
-    linear_algebra.mod_down_to_min_inplace(ct_vec1, ct_vec2);
+    linear_algebra.reduce_level_to_min_inplace(ct_vec1, ct_vec2);
     ASSERT_EQ(ct_vec1.he_level(), 0);
 
     EncryptedRowVector ct_vec3 = linear_algebra.encrypt_row_vector(vec1, unit);
-    linear_algebra.mod_down_to_min_inplace(ct_vec2, ct_vec3);
+    linear_algebra.reduce_level_to_min_inplace(ct_vec2, ct_vec3);
     ASSERT_EQ(ct_vec3.he_level(), 0);
 }
 
-TEST(LinearAlgebraTest, ModDownToLevel_Matrix) {
+TEST(LinearAlgebraTest, ReduceLevelTo_Matrix) {
     HomomorphicEval ckks_instance = HomomorphicEval(NUM_OF_SLOTS, ONE_MULTI_DEPTH, LOG_SCALE);
     LinearAlgebra linear_algebra = LinearAlgebra(ckks_instance);
 
@@ -1408,11 +1408,11 @@ TEST(LinearAlgebraTest, ModDownToLevel_Matrix) {
     Matrix mat1 = random_mat(128, 128);
 
     EncryptedMatrix ct_mat1 = linear_algebra.encrypt_matrix(mat1, unit);
-    EncryptedMatrix ct_mat2 = linear_algebra.mod_down_to_level(ct_mat1, 0);
+    EncryptedMatrix ct_mat2 = linear_algebra.reduce_level_to(ct_mat1, 0);
     ASSERT_EQ(ct_mat2.he_level(), 0);
 }
 
-TEST(LinearAlgebraTest, ModDownToLevel_ColVec) {
+TEST(LinearAlgebraTest, ReduceLevelTo_ColVec) {
     HomomorphicEval ckks_instance = HomomorphicEval(NUM_OF_SLOTS, ONE_MULTI_DEPTH, LOG_SCALE);
     LinearAlgebra linear_algebra = LinearAlgebra(ckks_instance);
 
@@ -1422,11 +1422,11 @@ TEST(LinearAlgebraTest, ModDownToLevel_ColVec) {
     Vector vec1 = random_vec(128);
 
     EncryptedColVector ct_vec1 = linear_algebra.encrypt_col_vector(vec1, unit);
-    EncryptedColVector ct_vec2 = linear_algebra.mod_down_to_level(ct_vec1, 0);
+    EncryptedColVector ct_vec2 = linear_algebra.reduce_level_to(ct_vec1, 0);
     ASSERT_EQ(ct_vec2.he_level(), 0);
 }
 
-TEST(LinearAlgebraTest, ModDownToLevel_RowVec) {
+TEST(LinearAlgebraTest, ReduceLevelTo_RowVec) {
     HomomorphicEval ckks_instance = HomomorphicEval(NUM_OF_SLOTS, ONE_MULTI_DEPTH, LOG_SCALE);
     LinearAlgebra linear_algebra = LinearAlgebra(ckks_instance);
 
@@ -1436,7 +1436,7 @@ TEST(LinearAlgebraTest, ModDownToLevel_RowVec) {
     Vector vec1 = random_vec(128);
 
     EncryptedRowVector ct_vec1 = linear_algebra.encrypt_row_vector(vec1, unit);
-    EncryptedRowVector ct_vec2 = linear_algebra.mod_down_to_level(ct_vec1, 0);
+    EncryptedRowVector ct_vec2 = linear_algebra.reduce_level_to(ct_vec1, 0);
     ASSERT_EQ(ct_vec2.he_level(), 0);
 }
 


### PR DESCRIPTION
*Issue #, if available:* Fixes #68

*Description of changes:*
The ciphertext maintenance tasks in the "mod_down_to" family (`mod_down_to`, `mod_down_to_level`, and `mod_down_to_min`, and the inplace counterparts) derived their name from a SEAL function. I find this name to be unclear, especially since we have a function called "rescale", which, to anyone knowledgeable about homomorphic encryption, sounds like the same thing. I've therefore decided to rename all of the `mod_down_to` family to `reduce_level_to`, which makes it clear what this function actually does. (It reduces the HE level).

The changes in this PR were accomplished by mass renaming of strings via, e.g., `find . -type f \( -iname \*.cpp -o -iname \*.h \) -exec sed -i 's/ModDownTo/ReduceLevelTo/g' {} +`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
