### PR TITLE
Plaintext param check

### DIFF
--- a/src/hit/api/evaluator/plaintext.cpp
+++ b/src/hit/api/evaluator/plaintext.cpp
@@ -19,7 +19,7 @@ namespace hit {
 
     PlaintextEval::PlaintextEval(int num_slots) : num_slots_(num_slots) {
         if (!is_pow2(num_slots)) {
-            throw invalid_argument("Numer of plaintext slots must be a power of two; got " + to_string(num_slots));\
+            throw invalid_argument("Numer of plaintext slots must be a power of two; got " + to_string(num_slots));
         }
     }
 


### PR DESCRIPTION
*Issue #, if available:* Fixes #69 

*Description of changes:*
Added a safety check to the `PlaintextEval` constructor to ensure that its argument is a power of two.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
