### PR TITLE
Make evaluator APIs consistent

### DIFF
--- a/src/hit/api/linearalgebra/linearalgebra.cpp
+++ b/src/hit/api/linearalgebra/linearalgebra.cpp
@@ -123,11 +123,11 @@ namespace hit {
     // explicit template instantiation
     template EncryptedMatrix LinearAlgebra::add(const EncryptedMatrix &, const EncryptedMatrix &);
     template void LinearAlgebra::add_inplace(EncryptedMatrix &, const EncryptedMatrix &);
-    template EncryptedMatrix LinearAlgebra::add(const vector<EncryptedMatrix> &);
-    template EncryptedMatrix LinearAlgebra::add(const EncryptedMatrix &, const Matrix &);
-    template EncryptedMatrix LinearAlgebra::add(const EncryptedMatrix &, double);
-    template void LinearAlgebra::add_inplace(EncryptedMatrix &enc_mat, double scalar);
-    template EncryptedMatrix LinearAlgebra::multiply(const EncryptedMatrix &, double);
+    template EncryptedMatrix LinearAlgebra::add_many(const vector<EncryptedMatrix> &);
+    template EncryptedMatrix LinearAlgebra::add_plain(const EncryptedMatrix &, const Matrix &);
+    template EncryptedMatrix LinearAlgebra::add_plain(const EncryptedMatrix &, double);
+    template void LinearAlgebra::add_plain_inplace(EncryptedMatrix &enc_mat, double scalar);
+    template EncryptedMatrix LinearAlgebra::multiply_plain(const EncryptedMatrix &, double);
     template void LinearAlgebra::reduce_level_to_min_inplace(EncryptedMatrix &, EncryptedMatrix &);
     template EncryptedMatrix LinearAlgebra::reduce_level_to(const EncryptedMatrix &, int);
     template void LinearAlgebra::reduce_level_to_inplace(EncryptedMatrix &, int);
@@ -148,11 +148,11 @@ namespace hit {
     // explicit template instantiation
     template EncryptedRowVector LinearAlgebra::add(const EncryptedRowVector &, const EncryptedRowVector &);
     template void LinearAlgebra::add_inplace(EncryptedRowVector &, const EncryptedRowVector &);
-    template EncryptedRowVector LinearAlgebra::add(const vector<EncryptedRowVector> &);
-    template EncryptedRowVector LinearAlgebra::add(const EncryptedRowVector &, const Vector &);
-    template EncryptedRowVector LinearAlgebra::add(const EncryptedRowVector &, double);
-    template void LinearAlgebra::add_inplace(EncryptedRowVector &enc_vec, double scalar);
-    template EncryptedRowVector LinearAlgebra::multiply(const EncryptedRowVector &, double);
+    template EncryptedRowVector LinearAlgebra::add_many(const vector<EncryptedRowVector> &);
+    template EncryptedRowVector LinearAlgebra::add_plain(const EncryptedRowVector &, const Vector &);
+    template EncryptedRowVector LinearAlgebra::add_plain(const EncryptedRowVector &, double);
+    template void LinearAlgebra::add_plain_inplace(EncryptedRowVector &enc_vec, double scalar);
+    template EncryptedRowVector LinearAlgebra::multiply_plain(const EncryptedRowVector &, double);
     template void LinearAlgebra::reduce_level_to_min_inplace(EncryptedRowVector &, EncryptedRowVector &);
     template EncryptedRowVector LinearAlgebra::reduce_level_to(const EncryptedRowVector &, int);
     template void LinearAlgebra::reduce_level_to_inplace(EncryptedRowVector &, int);
@@ -174,11 +174,11 @@ namespace hit {
     // explicit template instantiation
     template EncryptedColVector LinearAlgebra::add(const EncryptedColVector &, const EncryptedColVector &);
     template void LinearAlgebra::add_inplace(EncryptedColVector &, const EncryptedColVector &);
-    template EncryptedColVector LinearAlgebra::add(const vector<EncryptedColVector> &);
-    template EncryptedColVector LinearAlgebra::add(const EncryptedColVector &, const Vector &);
-    template EncryptedColVector LinearAlgebra::add(const EncryptedColVector &, double);
-    template void LinearAlgebra::add_inplace(EncryptedColVector &enc_vec, double scalar);
-    template EncryptedColVector LinearAlgebra::multiply(const EncryptedColVector &, double);
+    template EncryptedColVector LinearAlgebra::add_many(const vector<EncryptedColVector> &);
+    template EncryptedColVector LinearAlgebra::add_plain(const EncryptedColVector &, const Vector &);
+    template EncryptedColVector LinearAlgebra::add_plain(const EncryptedColVector &, double);
+    template void LinearAlgebra::add_plain_inplace(EncryptedColVector &enc_vec, double scalar);
+    template EncryptedColVector LinearAlgebra::multiply_plain(const EncryptedColVector &, double);
     template void LinearAlgebra::reduce_level_to_min_inplace(EncryptedColVector &, EncryptedColVector &);
     template EncryptedColVector LinearAlgebra::reduce_level_to(const EncryptedColVector &, int);
     template void LinearAlgebra::reduce_level_to_inplace(EncryptedColVector &, int);
@@ -197,7 +197,7 @@ namespace hit {
     template void LinearAlgebra::reduce_level_to_inplace(EncryptedColVector &, const EncryptedRowVector &);
     template void LinearAlgebra::reduce_level_to_inplace(EncryptedColVector &, const EncryptedColVector &);
 
-    void LinearAlgebra::add_inplace(EncryptedMatrix &enc_mat1, const Matrix &mat2) {
+    void LinearAlgebra::add_plain_inplace(EncryptedMatrix &enc_mat1, const Matrix &mat2) {
         if (!enc_mat1.initialized() || enc_mat1.height() != mat2.size1() || enc_mat1.width() != mat2.size2()) {
             throw invalid_argument("Arguments to LinearAlgebra::add_inplace do not have the same dimensions.");
         }
@@ -210,7 +210,7 @@ namespace hit {
         }
     }
 
-    void LinearAlgebra::add_inplace(EncryptedRowVector &enc_vec1, const Vector &vec2) {
+    void LinearAlgebra::add_plain_inplace(EncryptedRowVector &enc_vec1, const Vector &vec2) {
         if (!enc_vec1.initialized() || enc_vec1.width() != vec2.size()) {
             throw invalid_argument("Arguments to LinearAlgebra::add_inplace do not have the same dimensions.");
         }
@@ -221,7 +221,7 @@ namespace hit {
         }
     }
 
-    void LinearAlgebra::add_inplace(EncryptedColVector &enc_vec1, const Vector &vec2) {
+    void LinearAlgebra::add_plain_inplace(EncryptedColVector &enc_vec1, const Vector &vec2) {
         if (!enc_vec1.initialized() || enc_vec1.height() != vec2.size()) {
             throw invalid_argument("Arguments to LinearAlgebra::add_inplace do not have the same dimensions.");
         }

--- a/src/hit/api/linearalgebra/linearalgebra.h
+++ b/src/hit/api/linearalgebra/linearalgebra.h
@@ -88,19 +88,16 @@ namespace hit {
         /* Computes the sum of two linear algebra objects.
          * Inputs: One of the following options
          *   - EncryptedMatrix, EncryptedMatrix
-         *   - EncryptedMatrix, Matrix
          *   - EncryptedRowVector, EncryptedRowVector
-         *   - EncryptedRowVector, Vector
          *   - EncryptedColVector, EncryptedColVector
-         *   - EncryptedColVector, Vector
          *   where the dimensions of both arguments must be the same.
          * Output: The (encrypted) sum of the two objects
          *
          * Notes: This function has multiplicative depth zero and returns a linear ciphertext.
          */
-        template <typename T1, typename T2>
-        T1 add(const T1 &arg1, const T2 &arg2) {
-            T1 temp = arg1;
+        template <typename T>
+        T add(const T &arg1, const T &arg2) {
+            T temp = arg1;
             add_inplace(temp, arg2);
             return temp;
         }
@@ -130,26 +127,43 @@ namespace hit {
             }
         }
 
+        /* Computes the sum of two linear algebra objects.
+         * Inputs: One of the following options
+         *   - EncryptedMatrix, Matrix
+         *   - EncryptedRowVector, Vector
+         *   - EncryptedColVector, Vector
+         *   where the dimensions of both arguments must be the same.
+         * Output: The (encrypted) sum of the two objects
+         *
+         * Notes: This function has multiplicative depth zero and returns a linear ciphertext.
+         */
+        template <typename T1, typename T2>
+        T1 add_plain(const T1 &arg1, const T2 &arg2) {
+            T1 temp = arg1;
+            add_plain_inplace(temp, arg2);
+            return temp;
+        }
+
         /* Computes the sum of an encrypted matrix and a public matrix, where the result is stored in the first
          * argument. Inputs: An encrypted matrix and a public matrix, both with the same dimensions. Output: None
          *
          * Notes: This function has multiplicative depth zero and returns a linear ciphertext.
          */
-        void add_inplace(EncryptedMatrix &enc_mat1, const Matrix &mat2);
+        void add_plain_inplace(EncryptedMatrix &enc_mat1, const Matrix &mat2);
 
         /* Computes the sum of an encrypted row vector and a public vector, where the result is stored in the first
          * argument. Inputs: An encrypted vector and a public vector, both with the same dimensions. Output: None
          *
          * Notes: This function has multiplicative depth zero and returns a linear ciphertext.
          */
-        void add_inplace(EncryptedRowVector &enc_vec1, const Vector &vec2);
+        void add_plain_inplace(EncryptedRowVector &enc_vec1, const Vector &vec2);
 
         /* Computes the sum of an encrypted column vector and a public vector, where the result is stored in the first
          * argument. Inputs: An encrypted vector and a public vector, both with the same dimensions. Output: None
          *
          * Notes: This function has multiplicative depth zero and returns a linear ciphertext.
          */
-        void add_inplace(EncryptedColVector &enc_vec1, const Vector &vec2);
+        void add_plain_inplace(EncryptedColVector &enc_vec1, const Vector &vec2);
 
         /* Add a constant to each coefficient of the encrypted plaintext, putting the result in the first argument.
          * Inputs: One of the following options
@@ -161,7 +175,7 @@ namespace hit {
          * Notes: This function has multiplicative depth zero and returns a linear ciphertext.
          */
         template <typename T>
-        void add_inplace(T &arg, double scalar) {
+        void add_plain_inplace(T &arg, double scalar) {
             if (!arg.initialized()) {
                 throw std::invalid_argument("LinearAlgebra::add_inplace: argument not initialized.");
             }
@@ -180,9 +194,9 @@ namespace hit {
          * Notes: This function has multiplicative depth zero and returns a linear ciphertext.
          */
         template <typename T>
-        T add(const T &arg1, double scalar) {
+        T add_plain(const T &arg1, double scalar) {
             T temp = arg1;
-            add_inplace(temp, scalar);
+            add_plain_inplace(temp, scalar);
             return temp;
         }
 
@@ -197,9 +211,9 @@ namespace hit {
          * The input vector may not be empty.
          */
         template <typename T>
-        T add(const std::vector<T> &args) {
+        T add_many(const std::vector<T> &args) {
             if (args.empty()) {
-                throw std::invalid_argument("Vector of summands to LinearAlgebra::add cannot be empty.");
+                throw std::invalid_argument("Vector of summands to LinearAlgebra::add_many cannot be empty.");
             }
             // no further validation needed since we call a LinearAlgebra function
             T temp = args[0];
@@ -325,9 +339,9 @@ namespace hit {
          * the same level as the input, so it needs to be rescaled but *not* relinearized.
          */
         template <typename T>
-        T multiply(const T &arg1, double scalar) {
+        T multiply_plain(const T &arg1, double scalar) {
             T temp = arg1;
-            multiply_inplace(temp, scalar);
+            multiply_plain_inplace(temp, scalar);
             return temp;
         }
 
@@ -342,7 +356,7 @@ namespace hit {
          * the same level as the input, so it needs to be rescaled but *not* relinearized.
          */
         template <typename T>
-        void multiply_inplace(T &arg, double scalar) {
+        void multiply_plain_inplace(T &arg, double scalar) {
             if (!arg.initialized()) {
                 throw std::invalid_argument("LinearAlgebra::multiply_inplace: argument not initialized.");
             }

--- a/tests/api/linearalgebra/linearalgebra.cpp
+++ b/tests/api/linearalgebra/linearalgebra.cpp
@@ -268,10 +268,10 @@ TEST(LinearAlgebraTest, AddMatrixPlaintextMatrix_InvalidCase) {
 
     ASSERT_THROW(
         // Expect invalid_argument is thrown because widths do not match.
-        (linear_algebra.add_inplace(ciphertext1, mat2)), invalid_argument);
+        (linear_algebra.add_plain_inplace(ciphertext1, mat2)), invalid_argument);
     ASSERT_THROW(
         // Expect invalid_argument is thrown because heights do not match.
-        (linear_algebra.add_inplace(ciphertext1, mat3)), invalid_argument);
+        (linear_algebra.add_plain_inplace(ciphertext1, mat3)), invalid_argument);
 }
 
 TEST(LinearAlgebraTest, AddMatrixPlaintextMatrix) {
@@ -287,7 +287,7 @@ TEST(LinearAlgebraTest, AddMatrixPlaintextMatrix) {
     Matrix mat2 = random_mat(height, width);
     EncryptedMatrix ciphertext1 = linear_algebra.encrypt_matrix(mat1, unit1);
 
-    EncryptedMatrix ciphertext3 = linear_algebra.add(ciphertext1, mat2);
+    EncryptedMatrix ciphertext3 = linear_algebra.add_plain(ciphertext1, mat2);
     Matrix actual_result = linear_algebra.decrypt(ciphertext3);
     Matrix expected_result = mat1 + mat2;
     ASSERT_LT(diff2_norm(actual_result.data(), expected_result.data()), MAX_NORM);
@@ -306,7 +306,7 @@ TEST(LinearAlgebraTest, AddRowPlaintextRow_InvalidCase) {
 
     ASSERT_THROW(
         // Expect invalid_argument is thrown because sizes do not match.
-        (linear_algebra.add_inplace(ciphertext1, vec2)), invalid_argument);
+        (linear_algebra.add_plain_inplace(ciphertext1, vec2)), invalid_argument);
 }
 
 TEST(LinearAlgebraTest, AddRowPlaintextRow) {
@@ -321,7 +321,7 @@ TEST(LinearAlgebraTest, AddRowPlaintextRow) {
     Vector vec2 = random_vec(width);
     EncryptedRowVector ciphertext1 = linear_algebra.encrypt_row_vector(vec1, unit1);
 
-    EncryptedRowVector ciphertext3 = linear_algebra.add(ciphertext1, vec2);
+    EncryptedRowVector ciphertext3 = linear_algebra.add_plain(ciphertext1, vec2);
     Vector actual_result = linear_algebra.decrypt(ciphertext3);
     Vector expected_result = vec1 + vec2;
     ASSERT_LT(diff2_norm(actual_result.data(), expected_result.data()), MAX_NORM);
@@ -340,7 +340,7 @@ TEST(LinearAlgebraTest, AddColPlaintextCol_InvalidCase) {
 
     ASSERT_THROW(
         // Expect invalid_argument is thrown because sizes do not match.
-        (linear_algebra.add_inplace(ciphertext1, vec2)), invalid_argument);
+        (linear_algebra.add_plain_inplace(ciphertext1, vec2)), invalid_argument);
 }
 
 TEST(LinearAlgebraTest, AddColPlaintextCol) {
@@ -355,7 +355,7 @@ TEST(LinearAlgebraTest, AddColPlaintextCol) {
     Vector vec2 = random_vec(width);
     EncryptedColVector ciphertext1 = linear_algebra.encrypt_col_vector(vec1, unit1);
 
-    EncryptedColVector ciphertext3 = linear_algebra.add(ciphertext1, vec2);
+    EncryptedColVector ciphertext3 = linear_algebra.add_plain(ciphertext1, vec2);
     Vector actual_result = linear_algebra.decrypt(ciphertext3);
     Vector expected_result = vec1 + vec2;
     ASSERT_LT(diff2_norm(actual_result.data(), expected_result.data()), MAX_NORM);
@@ -375,7 +375,7 @@ TEST(LinearAlgebraTest, AddMatrixScalar) {
     Matrix mat2 = Matrix(height, width, vector<double>(height * width, scalar));
     EncryptedMatrix ciphertext1 = linear_algebra.encrypt_matrix(mat1, unit1);
 
-    EncryptedMatrix ciphertext3 = linear_algebra.add(ciphertext1, scalar);
+    EncryptedMatrix ciphertext3 = linear_algebra.add_plain(ciphertext1, scalar);
     Matrix actual_result = linear_algebra.decrypt(ciphertext3);
     Matrix expected_result = mat1 + mat2;
     ASSERT_LT(diff2_norm(actual_result.data(), expected_result.data()), MAX_NORM);
@@ -394,7 +394,7 @@ TEST(LinearAlgebraTest, AddRowScalar) {
     Vector vec2 = Vector(vector<double>(width, scalar));
     EncryptedRowVector ciphertext1 = linear_algebra.encrypt_row_vector(vec1, unit1);
 
-    EncryptedRowVector ciphertext3 = linear_algebra.add(ciphertext1, scalar);
+    EncryptedRowVector ciphertext3 = linear_algebra.add_plain(ciphertext1, scalar);
     Vector actual_result = linear_algebra.decrypt(ciphertext3);
     Vector expected_result = vec1 + vec2;
     ASSERT_LT(diff2_norm(actual_result.data(), expected_result.data()), MAX_NORM);
@@ -413,7 +413,7 @@ TEST(LinearAlgebraTest, AddColScalar) {
     Vector vec2 = Vector(vector<double>(height, scalar));
     EncryptedColVector ciphertext1 = linear_algebra.encrypt_col_vector(vec1, unit1);
 
-    EncryptedColVector ciphertext3 = linear_algebra.add(ciphertext1, scalar);
+    EncryptedColVector ciphertext3 = linear_algebra.add_plain(ciphertext1, scalar);
     Vector actual_result = linear_algebra.decrypt(ciphertext3);
     Vector expected_result = vec1 + vec2;
     ASSERT_LT(diff2_norm(actual_result.data(), expected_result.data()), MAX_NORM);
@@ -442,13 +442,13 @@ TEST(LinearAlgebraTest, AddMultipleMatrix_InvalidCase) {
 
     ASSERT_THROW(
         // Expect invalid_argument is thrown because widths do not match.
-        (linear_algebra.add(set1)), invalid_argument);
+        (linear_algebra.add_many(set1)), invalid_argument);
     ASSERT_THROW(
         // Expect invalid_argument is thrown because heights do not match.
-        (linear_algebra.add(set2)), invalid_argument);
+        (linear_algebra.add_many(set2)), invalid_argument);
     ASSERT_THROW(
         // Expect invalid_argument is thrown because encoding units do not match.
-        (linear_algebra.add(set3)), invalid_argument);
+        (linear_algebra.add_many(set3)), invalid_argument);
 }
 
 TEST(LinearAlgebraTest, AddMultipleMatrix) {
@@ -468,7 +468,7 @@ TEST(LinearAlgebraTest, AddMultipleMatrix) {
     Matrix matrix3 = random_mat(height, width);
     cts.emplace_back(linear_algebra.encrypt_matrix(matrix3, unit1));
 
-    EncryptedMatrix ciphertext = linear_algebra.add(cts);
+    EncryptedMatrix ciphertext = linear_algebra.add_many(cts);
     Matrix actual_result = linear_algebra.decrypt(ciphertext);
     Matrix expected_result = matrix1 + matrix2 + matrix3;
     ASSERT_LT(diff2_norm(actual_result.data(), expected_result.data()), MAX_NORM);
@@ -494,10 +494,10 @@ TEST(LinearAlgebraTest, AddMultipleRow_InvalidCase) {
 
     ASSERT_THROW(
         // Expect invalid_argument is thrown because dimensions do not match.
-        (linear_algebra.add(set1)), invalid_argument);
+        (linear_algebra.add_many(set1)), invalid_argument);
     ASSERT_THROW(
         // Expect invalid_argument is thrown because units do not match.
-        (linear_algebra.add(set2)), invalid_argument);
+        (linear_algebra.add_many(set2)), invalid_argument);
 }
 
 TEST(LinearAlgebraTest, AddMultipleRow) {
@@ -516,7 +516,7 @@ TEST(LinearAlgebraTest, AddMultipleRow) {
     Vector vec3 = random_vec(width);
     cts.emplace_back(linear_algebra.encrypt_row_vector(vec3, unit1));
 
-    EncryptedRowVector ciphertext = linear_algebra.add(cts);
+    EncryptedRowVector ciphertext = linear_algebra.add_many(cts);
     Vector actual_result = linear_algebra.decrypt(ciphertext);
     Vector expected_result = vec1 + vec2 + vec3;
     ASSERT_LT(diff2_norm(actual_result.data(), expected_result.data()), MAX_NORM);
@@ -542,10 +542,10 @@ TEST(LinearAlgebraTest, AddMultipleCol_InvalidCase) {
 
     ASSERT_THROW(
         // Expect invalid_argument is thrown because dimensions do not match.
-        (linear_algebra.add(set1)), invalid_argument);
+        (linear_algebra.add_many(set1)), invalid_argument);
     ASSERT_THROW(
         // Expect invalid_argument is thrown because units do not match.
-        (linear_algebra.add(set2)), invalid_argument);
+        (linear_algebra.add_many(set2)), invalid_argument);
 }
 
 TEST(LinearAlgebraTest, AddMultipleCol) {
@@ -564,7 +564,7 @@ TEST(LinearAlgebraTest, AddMultipleCol) {
     Vector vec3 = random_vec(width);
     cts.emplace_back(linear_algebra.encrypt_col_vector(vec3, unit1));
 
-    EncryptedColVector ciphertext = linear_algebra.add(cts);
+    EncryptedColVector ciphertext = linear_algebra.add_many(cts);
     Vector actual_result = linear_algebra.decrypt(ciphertext);
     Vector expected_result = vec1 + vec2 + vec3;
     ASSERT_LT(diff2_norm(actual_result.data(), expected_result.data()), MAX_NORM);
@@ -583,7 +583,7 @@ TEST(LinearAlgebraTest, MultiplyMatrixScalar) {
     double scalar = 3.14;
     EncryptedMatrix ciphertext1 = linear_algebra.encrypt_matrix(mat1, unit1);
 
-    EncryptedMatrix ciphertext3 = linear_algebra.multiply(ciphertext1, scalar);
+    EncryptedMatrix ciphertext3 = linear_algebra.multiply_plain(ciphertext1, scalar);
     Matrix actual_result = linear_algebra.decrypt(ciphertext3);
     Matrix expected_result = scalar * mat1;
     ASSERT_LT(diff2_norm(actual_result.data(), expected_result.data()), MAX_NORM);
@@ -601,7 +601,7 @@ TEST(LinearAlgebraTest, MultiplyRowScalar) {
     double scalar = 3.14;
     EncryptedRowVector ciphertext1 = linear_algebra.encrypt_row_vector(vec1, unit1);
 
-    EncryptedRowVector ciphertext3 = linear_algebra.multiply(ciphertext1, scalar);
+    EncryptedRowVector ciphertext3 = linear_algebra.multiply_plain(ciphertext1, scalar);
     Vector actual_result = linear_algebra.decrypt(ciphertext3);
     Vector expected_result = scalar * vec1;
     ASSERT_LT(diff2_norm(actual_result.data(), expected_result.data()), MAX_NORM);
@@ -619,7 +619,7 @@ TEST(LinearAlgebraTest, MultiplyColScalar) {
     double scalar = 3.14;
     EncryptedColVector ciphertext1 = linear_algebra.encrypt_col_vector(vec1, unit1);
 
-    EncryptedColVector ciphertext3 = linear_algebra.multiply(ciphertext1, scalar);
+    EncryptedColVector ciphertext3 = linear_algebra.multiply_plain(ciphertext1, scalar);
     Vector actual_result = linear_algebra.decrypt(ciphertext3);
     Vector expected_result = scalar * vec1;
     ASSERT_LT(diff2_norm(actual_result.data(), expected_result.data()), MAX_NORM);
@@ -975,7 +975,7 @@ TEST(LinearAlgebraTest, RescaleToNextMatrix) {
 
     Matrix mat = random_mat(64, 64);
     EncryptedMatrix ct_mat1 = linear_algebra.encrypt_matrix(mat, unit1);
-    EncryptedMatrix ct_mat2 = linear_algebra.multiply(ct_mat1, 3.14);
+    EncryptedMatrix ct_mat2 = linear_algebra.multiply_plain(ct_mat1, 3.14);
 
     ASSERT_EQ(pow(2, LOG_SCALE * 2), ct_mat2.scale());
     uint64_t prime = get_last_prime(ckks_instance.context, ct_mat1.he_level());
@@ -992,7 +992,7 @@ TEST(LinearAlgebraTest, RescaleToNextRow) {
 
     Vector vec = random_vec(64);
     EncryptedRowVector ct_vec1 = linear_algebra.encrypt_row_vector(vec, unit1);
-    EncryptedRowVector ct_vec2 = linear_algebra.multiply(ct_vec1, 3.14);
+    EncryptedRowVector ct_vec2 = linear_algebra.multiply_plain(ct_vec1, 3.14);
 
     ASSERT_EQ(pow(2, LOG_SCALE * 2), ct_vec2.scale());
     uint64_t prime = get_last_prime(ckks_instance.context, ct_vec1.he_level());
@@ -1009,7 +1009,7 @@ TEST(LinearAlgebraTest, RescaleToNextCol) {
 
     Vector vec = random_vec(64);
     EncryptedColVector ct_vec1 = linear_algebra.encrypt_col_vector(vec, unit1);
-    EncryptedColVector ct_vec2 = linear_algebra.multiply(ct_vec1, 3.14);
+    EncryptedColVector ct_vec2 = linear_algebra.multiply_plain(ct_vec1, 3.14);
 
     ASSERT_EQ(pow(2, LOG_SCALE * 2), ct_vec2.scale());
     uint64_t prime = get_last_prime(ckks_instance.context, ct_vec1.he_level());
@@ -1451,7 +1451,7 @@ TEST(LinearAlgebraTest, RescaleToNext_Matrix) {
 
     EncryptedMatrix ct_mat1 = linear_algebra.encrypt_matrix(mat1, unit);
     ASSERT_EQ(ct_mat1.scale(), pow(2, LOG_SCALE));
-    linear_algebra.multiply_inplace(ct_mat1, 2);
+    linear_algebra.multiply_plain_inplace(ct_mat1, 2);
     ASSERT_EQ(ct_mat1.scale(), pow(2, 2 * LOG_SCALE));
     ASSERT_EQ(ct_mat1.he_level(), 1);
     linear_algebra.rescale_to_next_inplace(ct_mat1);
@@ -1471,7 +1471,7 @@ TEST(LinearAlgebraTest, RescaleToNext_ColVec) {
 
     EncryptedColVector ct_vec1 = linear_algebra.encrypt_col_vector(vec1, unit);
     ASSERT_EQ(ct_vec1.scale(), pow(2, LOG_SCALE));
-    linear_algebra.multiply_inplace(ct_vec1, 2);
+    linear_algebra.multiply_plain_inplace(ct_vec1, 2);
     ASSERT_EQ(ct_vec1.scale(), pow(2, 2 * LOG_SCALE));
     ASSERT_EQ(ct_vec1.he_level(), 1);
     linear_algebra.rescale_to_next_inplace(ct_vec1);
@@ -1491,7 +1491,7 @@ TEST(LinearAlgebraTest, RescaleToNext_RowVec) {
 
     EncryptedRowVector ct_vec1 = linear_algebra.encrypt_row_vector(vec1, unit);
     ASSERT_EQ(ct_vec1.scale(), pow(2, LOG_SCALE));
-    linear_algebra.multiply_inplace(ct_vec1, 2);
+    linear_algebra.multiply_plain_inplace(ct_vec1, 2);
     ASSERT_EQ(ct_vec1.scale(), pow(2, 2 * LOG_SCALE));
     ASSERT_EQ(ct_vec1.he_level(), 1);
     linear_algebra.rescale_to_next_inplace(ct_vec1);


### PR DESCRIPTION

*Issue #, if available:* Fixes #73

*Description of changes:*
The evaluator API has functions like `add` and `add_plain`, while these were unified into a single `add` name in the linear algebra API. For consistency, I've modified the linear algebra API to use the `_plain` modifier for functions that take a plaintext argument.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
