### PR TITLE
Added save API to CKKSCiphertext and linear algebra types

### DIFF
--- a/src/hit/api/ciphertext.cpp
+++ b/src/hit/api/ciphertext.cpp
@@ -12,7 +12,7 @@ using namespace seal;
 
 namespace hit {
 
-    void CKKSCiphertext::readFromProto(const std::shared_ptr<seal::SEALContext> &context, const hit::protobuf::Ciphertext &proto_ct) {
+    void CKKSCiphertext::read_from_proto(const shared_ptr<seal::SEALContext> &context, const protobuf::Ciphertext &proto_ct) {
         initialized = proto_ct.initialized();
         scale_ = proto_ct.scale();
         he_level_ = proto_ct.he_level();
@@ -32,15 +32,14 @@ namespace hit {
         }
     }
 
-
     CKKSCiphertext::CKKSCiphertext(const shared_ptr<SEALContext> &context, const protobuf::Ciphertext &proto_ct) {
-        readFromProto(context, proto_ct);
+        read_from_proto(context, proto_ct);
     }
 
     CKKSCiphertext::CKKSCiphertext(const shared_ptr<SEALContext> &context, istream &stream) {
         protobuf::Ciphertext proto_ct;
         proto_ct.ParseFromIstream(&stream);
-        readFromProto(context, proto_ct);
+        read_from_proto(context, proto_ct);
     }
 
     protobuf::Ciphertext *CKKSCiphertext::serialize() const {

--- a/src/hit/api/ciphertext.h
+++ b/src/hit/api/ciphertext.h
@@ -16,7 +16,7 @@ namespace hit {
         CKKSCiphertext() = default;
 
         // Deserialize a ciphertext from a protobuf object
-        CKKSCiphertext(const std::shared_ptr<seal::SEALContext> &context, const hit::protobuf::Ciphertext &proto_ct);
+        CKKSCiphertext(const std::shared_ptr<seal::SEALContext> &context, const protobuf::Ciphertext &proto_ct);
 
         // Deserialize a ciphertext from a stream containing a protobuf object
         CKKSCiphertext(const std::shared_ptr<seal::SEALContext> &context, std::istream &stream);
@@ -27,7 +27,7 @@ namespace hit {
         // calling `delete` on the pointer. When passed as an argument to a protocol buffer
         // `add_allocated` function, ownership is transferred to the protocol buffer object,
         // which is responsible for releasing the memory allocated here.
-        hit::protobuf::Ciphertext *serialize() const;
+        protobuf::Ciphertext *serialize() const;
         // Serialize an ciphertext as a protobuf object to a stream.
         void save(std::ostream &stream) const;
 
@@ -47,7 +47,7 @@ namespace hit {
 
        private:
 
-        void readFromProto(const std::shared_ptr<seal::SEALContext> &context, const hit::protobuf::Ciphertext &proto_ct);
+        void read_from_proto(const std::shared_ptr<seal::SEALContext> &context, const protobuf::Ciphertext &proto_ct);
 
         // The raw plaintxt. This is used with some of the evaluators tha track ciphertext
         // metadata (e.g., DebugEval and PlaintextEval), but not by the Homomorphic evaluator.

--- a/src/hit/api/linearalgebra/encodingunit.cpp
+++ b/src/hit/api/linearalgebra/encodingunit.cpp
@@ -13,20 +13,20 @@ namespace hit {
         validate_init();
     }
 
-    void EncodingUnit::readFromProto(const protobuf::EncodingUnit &encoding_unit) {
+    void EncodingUnit::read_from_proto(const protobuf::EncodingUnit &encoding_unit) {
         encoding_height_ = encoding_unit.encoding_height();
         encoding_width_ = encoding_unit.encoding_width();
         validate_init();
     }
 
     EncodingUnit::EncodingUnit(const protobuf::EncodingUnit &encoding_unit) {
-        readFromProto(encoding_unit);
+        read_from_proto(encoding_unit);
     }
 
     EncodingUnit::EncodingUnit(istream &stream) {
         protobuf::EncodingUnit proto_unit;
         proto_unit.ParseFromIstream(&stream);
-        readFromProto(proto_unit);
+        read_from_proto(proto_unit);
     }
 
     bool operator==(const EncodingUnit &lhs, const EncodingUnit &rhs) {

--- a/src/hit/api/linearalgebra/encodingunit.h
+++ b/src/hit/api/linearalgebra/encodingunit.h
@@ -51,7 +51,7 @@ namespace hit {
         EncodingUnit transpose() const;
 
        private:
-        void readFromProto(const protobuf::EncodingUnit &encoding_unit);
+        void read_from_proto(const protobuf::EncodingUnit &encoding_unit);
         // use `make_unit` in `LinearAlgebra` to construct an encoding unit
         EncodingUnit() = default;
         EncodingUnit(int encoding_height, int encoding_width);

--- a/src/hit/api/linearalgebra/encryptedcolvector.cpp
+++ b/src/hit/api/linearalgebra/encryptedcolvector.cpp
@@ -9,13 +9,13 @@
 using namespace std;
 
 namespace hit {
-    EncryptedColVector::EncryptedColVector(int height, const EncodingUnit &unit, std::vector<CKKSCiphertext> &cts)
+    EncryptedColVector::EncryptedColVector(int height, const EncodingUnit &unit, vector<CKKSCiphertext> &cts)
         : height_(height), unit(unit), cts(cts) {
         validate_init();
     }
 
-    void EncryptedColVector::readFromProto(const std::shared_ptr<seal::SEALContext> &context,
-                                           const protobuf::EncryptedColVector &encrypted_col_vector) {
+    void EncryptedColVector::read_from_proto(const shared_ptr<seal::SEALContext> &context,
+                                             const protobuf::EncryptedColVector &encrypted_col_vector) {
         height_ = encrypted_col_vector.height();
         unit = EncodingUnit(encrypted_col_vector.unit());
         cts.reserve(encrypted_col_vector.cts().cts_size());
@@ -23,16 +23,16 @@ namespace hit {
         validate_init();
     }
 
-    EncryptedColVector::EncryptedColVector(const std::shared_ptr<seal::SEALContext> &context,
+    EncryptedColVector::EncryptedColVector(const shared_ptr<seal::SEALContext> &context,
                                            const protobuf::EncryptedColVector &encrypted_col_vector) {
-        readFromProto(context, encrypted_col_vector);
+        read_from_proto(context, encrypted_col_vector);
     }
 
-    EncryptedColVector::EncryptedColVector(const std::shared_ptr<seal::SEALContext> &context,
-                                           std::istream &stream) {
+    EncryptedColVector::EncryptedColVector(const shared_ptr<seal::SEALContext> &context,
+                                           istream &stream) {
         protobuf::EncryptedColVector proto_vec;
         proto_vec.ParseFromIstream(&stream);
-        readFromProto(context, proto_vec);
+        read_from_proto(context, proto_vec);
     }
 
     protobuf::EncryptedColVector *EncryptedColVector::serialize() const {

--- a/src/hit/api/linearalgebra/encryptedcolvector.h
+++ b/src/hit/api/linearalgebra/encryptedcolvector.h
@@ -70,8 +70,8 @@ namespace hit {
         Vector plaintext() const override;
 
        private:
-        void readFromProto(const std::shared_ptr<seal::SEALContext> &context,
-                           const protobuf::EncryptedColVector &encrypted_col_vector);
+        void read_from_proto(const std::shared_ptr<seal::SEALContext> &context,
+                             const protobuf::EncryptedColVector &encrypted_col_vector);
 
         EncryptedColVector(int height, const EncodingUnit &unit, std::vector<CKKSCiphertext> &cts);
 

--- a/src/hit/api/linearalgebra/encryptedmatrix.cpp
+++ b/src/hit/api/linearalgebra/encryptedmatrix.cpp
@@ -15,8 +15,8 @@ namespace hit {
         validate_init();
     }
 
-    void EncryptedMatrix::readFromProto(const std::shared_ptr<seal::SEALContext> &context,
-                                        const protobuf::EncryptedMatrix &encrypted_matrix) {
+    void EncryptedMatrix::read_from_proto(const shared_ptr<seal::SEALContext> &context,
+                                          const protobuf::EncryptedMatrix &encrypted_matrix) {
         height_ = encrypted_matrix.height();
         width_ = encrypted_matrix.width();
         unit = EncodingUnit(encrypted_matrix.unit());
@@ -32,9 +32,15 @@ namespace hit {
         validate_init();
     }
 
-    EncryptedMatrix::EncryptedMatrix(const std::shared_ptr<seal::SEALContext> &context,
+    EncryptedMatrix::EncryptedMatrix(const shared_ptr<seal::SEALContext> &context,
                                      const protobuf::EncryptedMatrix &encrypted_matrix) {
-        readFromProto(context, encrypted_matrix);
+        read_from_proto(context, encrypted_matrix);
+    }
+
+    EncryptedMatrix::EncryptedMatrix(const shared_ptr<seal::SEALContext> &context, istream &stream) {
+        protobuf::EncryptedMatrix proto_mat;
+        proto_mat.ParseFromIstream(&stream);
+        read_from_proto(context, proto_mat);
     }
 
     protobuf::EncryptedMatrix *EncryptedMatrix::serialize() const {

--- a/src/hit/api/linearalgebra/encryptedmatrix.h
+++ b/src/hit/api/linearalgebra/encryptedmatrix.h
@@ -81,8 +81,8 @@ namespace hit {
         Matrix plaintext() const override;
 
        private:
-        void readFromProto(const std::shared_ptr<seal::SEALContext> &context,
-                           const protobuf::EncryptedMatrix &encrypted_matrix);
+        void read_from_proto(const std::shared_ptr<seal::SEALContext> &context,
+                             const protobuf::EncryptedMatrix &encrypted_matrix);
 
         EncryptedMatrix(int height, int width, const EncodingUnit &unit,
                         const std::vector<std::vector<CKKSCiphertext>> &cts);

--- a/src/hit/api/linearalgebra/encryptedrowvector.cpp
+++ b/src/hit/api/linearalgebra/encryptedrowvector.cpp
@@ -11,13 +11,13 @@
 using namespace std;
 
 namespace hit {
-    EncryptedRowVector::EncryptedRowVector(int width, const EncodingUnit &unit, std::vector<CKKSCiphertext> &cts)
+    EncryptedRowVector::EncryptedRowVector(int width, const EncodingUnit &unit, vector<CKKSCiphertext> &cts)
         : width_(width), unit(unit), cts(cts) {
         validate_init();
     }
 
-    void EncryptedRowVector::readFromProto(const std::shared_ptr<seal::SEALContext> &context,
-                                           const protobuf::EncryptedRowVector &encrypted_row_vector) {
+    void EncryptedRowVector::read_from_proto(const shared_ptr<seal::SEALContext> &context,
+                                             const protobuf::EncryptedRowVector &encrypted_row_vector) {
         width_ = encrypted_row_vector.width();
         unit = EncodingUnit(encrypted_row_vector.unit());
 
@@ -26,16 +26,16 @@ namespace hit {
         validate_init();
     }
 
-    EncryptedRowVector::EncryptedRowVector(const std::shared_ptr<seal::SEALContext> &context,
+    EncryptedRowVector::EncryptedRowVector(const shared_ptr<seal::SEALContext> &context,
                                            const protobuf::EncryptedRowVector &encrypted_row_vector) {
-        readFromProto(context, encrypted_row_vector);
+        read_from_proto(context, encrypted_row_vector);
     }
 
-    EncryptedRowVector::EncryptedRowVector(const std::shared_ptr<seal::SEALContext> &context,
-                                           std::istream &stream) {
+    EncryptedRowVector::EncryptedRowVector(const shared_ptr<seal::SEALContext> &context,
+                                           istream &stream) {
         protobuf::EncryptedRowVector proto_vec;
         proto_vec.ParseFromIstream(&stream);
-        readFromProto(context, proto_vec);
+        read_from_proto(context, proto_vec);
     }
 
     protobuf::EncryptedRowVector *EncryptedRowVector::serialize() const {

--- a/src/hit/api/linearalgebra/encryptedrowvector.h
+++ b/src/hit/api/linearalgebra/encryptedrowvector.h
@@ -86,8 +86,8 @@ namespace hit {
         Vector plaintext() const override;
 
        private:
-        void readFromProto(const std::shared_ptr<seal::SEALContext> &context,
-                           const protobuf::EncryptedRowVector &encrypted_row_vector);
+        void read_from_proto(const std::shared_ptr<seal::SEALContext> &context,
+                             const protobuf::EncryptedRowVector &encrypted_row_vector);
 
         EncryptedRowVector(int width, const EncodingUnit &unit, std::vector<CKKSCiphertext> &cts);
 


### PR DESCRIPTION
*Issue #, if available:* Fixes #85

*Description of changes:*
Currently, serializing HIT objects requires the user to go through protobufs. This means they have to know how to use the protobuf API, and remember to free the pointer of the serialized object. Moreover, there's an inconsistency between how we serialize the instance (paramters, galois keys, relin keys, and secret key), which (by necessity) uses a function `save()` that takes `ostream`s, and how we serialize various encrypted objects via `serialize()` which works with protobuf pointers.

This PR unifies the API so the user never has to deal with protobuf objects. The `serialize()` API is still important for applications which want to package their own ciphertexts, but the `save()` API offers a quick-and-simple way to serialize an object without having to open the protocol buffers documentation.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
