### PR TITLE
Added parallelism to all expensive operations in linear algebra

### DIFF
--- a/src/hit/api/linearalgebra/linearalgebra.cpp
+++ b/src/hit/api/linearalgebra/linearalgebra.cpp
@@ -371,8 +371,7 @@ namespace hit {
 
         vector<vector<CKKSCiphertext>> cts = enc_mat.cts;
 
-        vector<int> iterIdxs = gen_for_each_iters(enc_mat.num_vertical_units()*enc_mat.num_horizontal_units());
-        for_each(execution::par, begin(iterIdxs), end(iterIdxs), [&](int i) {
+        parallel_for(enc_mat.num_vertical_units()*enc_mat.num_horizontal_units(), [&](int i) {
             int unit_row = i / enc_mat.num_horizontal_units();
             int unit_col = i % enc_mat.num_horizontal_units();
             eval.multiply_inplace(cts[unit_row][unit_col], enc_vec.cts[unit_row]);
@@ -416,8 +415,7 @@ namespace hit {
 
         vector<vector<CKKSCiphertext>> cts = enc_mat.cts;
 
-        vector<int> iterIdxs = gen_for_each_iters(enc_mat.num_vertical_units()*enc_mat.num_horizontal_units());
-        for_each(execution::par, begin(iterIdxs), end(iterIdxs), [&](int i) {
+        parallel_for(enc_mat.num_vertical_units()*enc_mat.num_horizontal_units(), [&](int i) {
             int unit_row = i / enc_mat.num_horizontal_units();
             int unit_col = i % enc_mat.num_horizontal_units();
             eval.multiply_inplace(cts[unit_row][unit_col], enc_vec.cts[unit_col]);
@@ -467,8 +465,7 @@ namespace hit {
         }
 
         vector<CKKSCiphertext> isolated_row_cts(enc_mat_b_trans.num_horizontal_units());
-        vector<int> iterIdxs = gen_for_each_iters(enc_mat_b_trans.num_horizontal_units());
-        for_each(execution::par, begin(iterIdxs), end(iterIdxs), [&](int j) {
+        parallel_for(enc_mat_b_trans.num_horizontal_units(), [&](int j) {
             isolated_row_cts[j] = eval.multiply_plain(enc_mat_b_trans.cts[unit_row][j], row_mask);
             eval.rescale_to_next_inplace(isolated_row_cts[j]);
             // we now have isolated the k^th row of B^T. To get an encoding of the k^th column of B
@@ -513,8 +510,7 @@ namespace hit {
         }
 
         vector<CKKSCiphertext> isolated_col_cts(enc_mat_a_trans.num_vertical_units());
-        vector<int> iterIdxs = gen_for_each_iters(enc_mat_a_trans.num_vertical_units());
-        for_each(execution::par, begin(iterIdxs), end(iterIdxs), [&](int i) {
+        parallel_for(enc_mat_a_trans.num_vertical_units(), [&](int i) {
             isolated_col_cts[i] = eval.multiply_plain(enc_mat_a_trans.cts[i][unit_col], col_mask);
             eval.rescale_to_next_inplace(isolated_col_cts[i]);
             // we now have isolated the k^th column of A^T. To get an encoding of the k^th row of A
@@ -566,8 +562,7 @@ namespace hit {
         }
 
         vector<CKKSCiphertext> row_cts(enc_mat_a.num_vertical_units());
-        vector<int> iterIdxs = gen_for_each_iters(enc_mat_a.num_vertical_units());
-        for_each(execution::par, begin(iterIdxs), end(iterIdxs), [&](int i) {
+        parallel_for(enc_mat_a.num_vertical_units(), [&](int i) {
             // sum the units in this row
             CKKSCiphertext unit_sum = eval.add_many(hmul_A_times_kth_col_B.cts[i]);
             // sum the columns of the unit, putting the result in the first column
@@ -677,8 +672,7 @@ namespace hit {
         // then combine the results for each column to get the matrix product
         vector<EncryptedRowVector> col_results(enc_mat_b_trans.height());
 
-        vector<int> iterIdxs = gen_for_each_iters(enc_mat_b_trans.height());
-        for_each(execution::par, begin(iterIdxs), end(iterIdxs), [&](int k) {
+        parallel_for(enc_mat_b_trans.height(), [&](int k) {
             col_results[k] = matrix_matrix_mul_loop_col_major(enc_mat_a, enc_mat_b_trans, scalar, k);
         });
 
@@ -725,8 +719,7 @@ namespace hit {
         // then combine the results for each row to get the matrix product
         vector<EncryptedColVector> row_results(enc_mat_a_trans.width());
 
-        vector<int> iterIdxs = gen_for_each_iters(enc_mat_a_trans.width());
-        for_each(execution::par, begin(iterIdxs), end(iterIdxs), [&](int k) {
+        parallel_for(enc_mat_a_trans.width(), [&](int k) {
             row_results[k] = matrix_matrix_mul_loop_row_major(enc_mat_a_trans, enc_mat_b, scalar, k, transpose_unit);
         });
 
@@ -893,8 +886,7 @@ namespace hit {
 
         vector<CKKSCiphertext> cts(enc_mat.num_vertical_units());
 
-        vector<int> iterIdxs = gen_for_each_iters(enc_mat.num_vertical_units());
-        for_each(execution::par, begin(iterIdxs), end(iterIdxs), [&](int i) {
+        parallel_for(enc_mat.num_vertical_units(), [&](int i) {
             cts[i] = sum_cols_core(eval.add_many(enc_mat.cts[i]), enc_mat.encoding_unit(), scalar);
         });
 
@@ -996,8 +988,7 @@ namespace hit {
         }
         vector<CKKSCiphertext> cts(enc_mat.num_horizontal_units());
 
-        vector<int> iterIdxs = gen_for_each_iters(enc_mat.num_horizontal_units());
-        for_each(execution::par, begin(iterIdxs), end(iterIdxs),
+        parallel_for(enc_mat.num_horizontal_units(),
                       [&](int j) { cts[j] = sum_rows_core(enc_mat, j);
         });
 

--- a/src/hit/api/linearalgebra/linearalgebra.h
+++ b/src/hit/api/linearalgebra/linearalgebra.h
@@ -28,6 +28,25 @@
  * more details.
  */
 
+/* Intended usage is:
+ *
+ *      parallel_for(x.size(), i) {
+ *          foo1;
+ *          foo2;
+ *          ...
+ *          foon;
+ *      });
+ */
+
+// https://stackoverflow.com/a/10379844/925978
+#define COMBINE1(X,Y) X##Y  // helper macro
+#define COMBINE(X,Y) COMBINE1(X,Y)
+// https://stackoverflow.com/a/17694752/925978
+#define parallel_for(max_idx, body)\
+    std::vector<int> COMBINE(iterIdxs, __LINE__)(max_idx);\
+    std::iota(begin(COMBINE(iterIdxs, __LINE__)), end(COMBINE(iterIdxs, __LINE__)), 0);\
+    for_each(__pstl::execution::par, begin(COMBINE(iterIdxs, __LINE__)), end(COMBINE(iterIdxs, __LINE__)), body)
+
 namespace hit {
 
     // Evaluation and Encryption API for Linear Algebra objects
@@ -715,8 +734,10 @@ namespace hit {
                            << ", Matrix: " << arg2.needs_relin());
             }
 
-            std::vector<int> iterIdxs = gen_for_each_iters(arg1.num_cts());
-            for_each(__pstl::execution::par, begin(iterIdxs), end(iterIdxs), [&](int i) {
+            // parallel_for(arg1.num_cts(), i) {
+            //     eval.multiply_inplace(arg1[i], arg2[i]);
+            // };
+            parallel_for(arg1.num_cts(), [&](int i) {
                 eval.multiply_inplace(arg1[i], arg2[i]);
             });
         }
@@ -770,8 +791,7 @@ namespace hit {
                 LOG_AND_THROW_STREAM("Input to hadamard_square must have nominal scale");
             }
 
-            std::vector<int> iterIdxs = gen_for_each_iters(arg.num_cts());
-            for_each(__pstl::execution::par, begin(iterIdxs), end(iterIdxs), [&](int i) {
+            parallel_for(arg.num_cts(), [&](int i) {
                 eval.square_inplace(arg[i]);
             });
         }
@@ -977,8 +997,7 @@ namespace hit {
                 LOG_AND_THROW_STREAM("Input to reduce_level_to is not initialized");
             }
 
-            std::vector<int> iterIdxs = gen_for_each_iters(arg.num_cts());
-            for_each(__pstl::execution::par, begin(iterIdxs), end(iterIdxs), [&](int i) {
+            parallel_for(arg.num_cts(), [&](int i) {
                 eval.reduce_level_to_inplace(arg[i], level);
             });
         }
@@ -1010,8 +1029,7 @@ namespace hit {
                 LOG_AND_THROW_STREAM("Inputs to rescale_to_next is not initialized");
             }
 
-            std::vector<int> iterIdxs = gen_for_each_iters(arg.num_cts());
-            for_each(__pstl::execution::par, begin(iterIdxs), end(iterIdxs), [&](int i) {
+            parallel_for(arg.num_cts(), [&](int i) {
                 eval.rescale_to_next_inplace(arg[i]);
             });
         }
@@ -1040,8 +1058,7 @@ namespace hit {
                 LOG_AND_THROW_STREAM("Inputs to relinearize is not initialized");
             }
 
-            std::vector<int> iterIdxs = gen_for_each_iters(arg.num_cts());
-            for_each(__pstl::execution::par, begin(iterIdxs), end(iterIdxs), [&](int i) {
+            parallel_for(arg.num_cts(), [&](int i) {
                 eval.relinearize_inplace(arg[i]);
             });
         }

--- a/src/hit/common.h
+++ b/src/hit/common.h
@@ -85,14 +85,6 @@ namespace hit {
         }
     }
 
-    inline std::vector<int> gen_for_each_iters(int iters) {
-        std::vector<int> iterIdxs(iters);
-        for (int i = 0; i < iters; i++) {
-            iterIdxs[i] = i;
-        }
-        return iterIdxs;
-    }
-
     void decryption_warning(int level);
 
 }  // namespace hit


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Added parallelism to expensive linear algebra operations, especially matrix-matrix multiplication. This should improve performance, but more importantly it makes the function performance much easier to describe, so the documentation now matches the implementation.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
