### PR TITLE
Updated SEAL version and TBB version

### DIFF
--- a/cmake/modules/FindSealLib.cmake
+++ b/cmake/modules/FindSealLib.cmake
@@ -1,6 +1,6 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-# Download and install test dependency - Microsoft SEAL.
+# Download and install dependency - Microsoft SEAL.
 download_external_project("seal")
-find_package(SEAL 3.5 REQUIRED)
+find_package(SEAL 3.6 REQUIRED)

--- a/cmake/modules/FindTbbLib.cmake
+++ b/cmake/modules/FindTbbLib.cmake
@@ -1,23 +1,17 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-set(TBB_CMAKE_FILE ${3P_INSTALL_DIR}/TBBGet.cmake)
+download_external_project("tbb")
 
-# Download a single CMake file from TBB 2020
-# This file is used to download the correct binary package for this system
-file(
-	DOWNLOAD
-		https://raw.githubusercontent.com/oneapi-src/oneTBB/tbb_2020/cmake/TBBGet.cmake
-		${TBB_CMAKE_FILE}
-)
 # Load the TBB CMake file
-include(${TBB_CMAKE_FILE})
+include(${HIT_THIRD_PARTY_DIR}/tbb/src/tbb/cmake/TBBGet.cmake)
+include(${HIT_THIRD_PARTY_DIR}/tbb/src/tbb/cmake/TBBMakeConfig.cmake)
 message(STATUS "Installing TBB...")
 # Invoke it to automatically download the correct binary package for this system
 # Unpack the downloaded content to ${3P_INSTALL_DIR}
 # See https://sudonull.com/post/68014-Integration-of-Intel-Threading-Building-Blocks-into-your-CMake-project-Intel-Blog
 # for details on the tbb_get arguments.
-tbb_get(TBB_ROOT tbb_root CONFIG_DIR TBB_DIR SAVE_TO ${3P_INSTALL_DIR})
+tbb_get(TBB_ROOT tbb_root RELEASE_TAG v2020.3 CONFIG_DIR TBB_DIR SAVE_TO ${3P_INSTALL_DIR})
 # Runtime linker error with GCC-9 in CI if I _don't_ specify the TBB components
 # The problem seems to be that the default is to use more components, but the linker
 # can't find the shared libraries of the (unused) components.

--- a/src/hit/api/ciphertext.cpp
+++ b/src/hit/api/ciphertext.cpp
@@ -34,7 +34,7 @@ namespace hit {
 
         if (proto_ct.has_seal_ct()) {
             istringstream ctstream(proto_ct.seal_ct());
-            seal_ct.load(context, ctstream);
+            seal_ct.load(*context, ctstream);
         }
     }
 

--- a/src/hit/api/evaluator/scaleestimator.cpp
+++ b/src/hit/api/evaluator/scaleestimator.cpp
@@ -44,12 +44,12 @@ namespace hit {
                                  << log_scale_ << " bits require more than " << num_slots << " plaintext slots.");
         }
 
-        EncryptionParameters params = EncryptionParameters(scheme_type::CKKS);
+        EncryptionParameters params = EncryptionParameters(scheme_type::ckks);
         params.set_poly_modulus_degree(poly_modulus_degree);
         params.set_coeff_modulus(CoeffModulus::Create(poly_modulus_degree, modulusVector));
 
         // for large parameter sets, see https://github.com/microsoft/SEAL/issues/84
-        context = SEALContext::Create(params, true, sec_level_type::none);
+        context = make_unique<SEALContext>(params, true, sec_level_type::none);
 
         // if scale is too close to 60, SEAL throws the error "encoded values are too large" during encoding.
         estimated_max_log_scale_ = PLAINTEXT_LOG_MAX - 60;

--- a/src/hit/sealutils.cpp
+++ b/src/hit/sealutils.cpp
@@ -62,7 +62,7 @@ namespace hit {
         /*
         For the BFV scheme print the plain_modulus parameter.
         */
-        if (context_data.parms().scheme() == scheme_type::BFV) {
+        if (context_data.parms().scheme() == scheme_type::bfv) {
             VLOG(VLOG_VERBOSE) << "|   plain_modulus: " << context_data.parms().plain_modulus().value();
         }
 

--- a/third-party/seal/CMakeLists.txt
+++ b/third-party/seal/CMakeLists.txt
@@ -5,7 +5,7 @@ cmake_minimum_required(VERSION 3.12)
 
 message(STATUS "Downloading Microsoft SEAL in ${CMAKE_CURRENT_LIST_DIR}.")
 
-project(SEAL_DOWNLOAD VERSION 3.5.9)
+project(SEAL_DOWNLOAD VERSION 3.6.1)
 
 include(ExternalProject)
 ExternalProject_Add(EP_SEAL

--- a/third-party/tbb/CMakeLists.txt
+++ b/third-party/tbb/CMakeLists.txt
@@ -1,0 +1,19 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+cmake_minimum_required(VERSION 3.12)
+
+message(STATUS "Downloading Intel TBB in ${CMAKE_CURRENT_LIST_DIR}.")
+
+project(TBB_DOWNLOAD VERSION 2021.1.1)
+
+include(ExternalProject)
+ExternalProject_Add(EP_TBB
+	URL                  https://github.com/oneapi-src/oneTBB/releases/download/v2020.3/tbb-2020.3-lin.tgz
+    DOWNLOAD_DIR         ${CMAKE_CURRENT_LIST_DIR}
+    SOURCE_DIR           ${CMAKE_CURRENT_LIST_DIR}/src
+    CONFIGURE_COMMAND    ""
+    BUILD_COMMAND        ""
+    INSTALL_COMMAND      ""
+    TEST_COMMAND         ""
+)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This PR updates the dependency versions for SEAL (3.5.9->3.6.1) and OneTBB. The new version of SEAL updates a few APIs, so it was necessary to update some SEAL API calls throughout HIT. 

OneTBB pushed a new version, which didn't work with how we were building it. As a result, I've modified the OneTBB build to download a tar file and install the 2020 version. I couldn't get the 2021 version to install, no matter what I tried.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
