### PR TITLE
Build system improvements

### DIFF
--- a/cmake/download-external-project.cmake
+++ b/cmake/download-external-project.cmake
@@ -2,13 +2,17 @@
 # SPDX-License-Identifier: Apache-2.0
 
 function(download_external_project project_dir)
-    set(EXTERNAL_PROJECT_CMAKE_CACHE_FILE ${HIT_THIRD_PARTY_DIR}/${project_dir}/CMakeCache.txt)
-    if(EXISTS ${EXTERNAL_PROJECT_CMAKE_CACHE_FILE})
-        message(STATUS "Removing old ${EXTERNAL_PROJECT_CMAKE_CACHE_FILE}")
-        file(REMOVE ${EXTERNAL_PROJECT_CMAKE_CACHE_FILE})
-    endif()
     set(COMMAND_WORK_DIR ${HIT_THIRD_PARTY_DIR}/${project_dir})
-    message(STATUS "Downloading ${project_dir}...")
+    message(STATUS "Cleaning ${project_dir} directory...")
+    execute_process(
+        # delete all items in ${COMMAND_WORK_DIR} _execpt_
+        #  - CMakeLists.txt (which is part of the repo)
+        #  - src/, which is where our build system unpacks the downloaded content. If this folder exists, we don't need to re-download
+        COMMAND find . -maxdepth 1 \( ! -name "CMakeLists.txt" ! -name "." ! -path "./src" \) -exec rm -rf {} \;
+        RESULT_VARIABLE result
+        WORKING_DIRECTORY ${COMMAND_WORK_DIR}
+        OUTPUT_QUIET)
+    message(STATUS "Obtaining ${project_dir}...")
     execute_process(
         COMMAND ${CMAKE_COMMAND} -G "${CMAKE_GENERATOR}" . -D3P_INSTALL_DIR=${3P_INSTALL_DIR}
         RESULT_VARIABLE result

--- a/cmake/set-common-flags.cmake
+++ b/cmake/set-common-flags.cmake
@@ -2,13 +2,13 @@
 # SPDX-License-Identifier: Apache-2.0
 
 function(set_common_flags target_name)
-    target_compile_options(${target_name} PUBLIC -std=c++17 -Wall -Werror -Wformat=2 -Wwrite-strings -Wvla
+    target_compile_options(${target_name} PRIVATE -std=c++17 -Wall -Werror -Wformat=2 -Wwrite-strings -Wvla
             -fvisibility=hidden -fno-common -funsigned-char -Wextra -Wunused -Wcomment -Wchar-subscripts -Wuninitialized
             -Wunused-result -Wfatal-errors)
     if (CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
-        target_compile_options(${target_name} PUBLIC -Wmissing-declarations -Wmissing-field-initializers -Wshadow
+        target_compile_options(${target_name} PRIVATE -Wmissing-declarations -Wmissing-field-initializers -Wshadow
                 -Wpedantic)
     endif()
     #-Wextra turns on sign-compare which is strict on comparing loop indexes (int) with size_t from vector length
-    target_compile_options(${target_name} PUBLIC -Wno-sign-compare)
+    target_compile_options(${target_name} PRIVATE -Wno-sign-compare)
 endfunction()

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -13,6 +13,7 @@ list(APPEND HIT_TEST_FILES "testutil.cpp")
 add_executable(hit-unit-tests ${HIT_TEST_FILES})
 
 target_link_libraries(hit-unit-tests PRIVATE aws-hit ${gtest_LIBRARIES})
+target_include_directories(hit-unit-tests PRIVATE ${3P_INSTALL_DIR}/include)
 set_common_flags(hit-unit-tests)
 
 add_custom_target(NAME hit-unit-tests COMMAND hit-unit-tests)

--- a/third-party/glog/CMakeLists.txt
+++ b/third-party/glog/CMakeLists.txt
@@ -5,7 +5,13 @@ cmake_minimum_required(VERSION 3.12)
 
 project(GLOG_DOWNLOAD VERSION 0.4.0)
 
-message(STATUS "Downloading GoogleGlog in ${CMAKE_CURRENT_LIST_DIR}.")
+if (EXISTS ${CMAKE_CURRENT_LIST_DIR}/src)
+    set(DOWNLOAD_URL)
+    message(STATUS "Found source code for GoogleGlog in ${CMAKE_CURRENT_LIST_DIR}.")
+else()
+    message(STATUS "No source code found for GoogleGlog; downloading in ${CMAKE_CURRENT_LIST_DIR}.")
+    set(DOWNLOAD_URL https://github.com/google/glog.git)
+endif()
 
 include(ExternalProject)
 ExternalProject_Add(EP_GLOG
@@ -13,8 +19,9 @@ ExternalProject_Add(EP_GLOG
     STAMP_DIR            ${CMAKE_CURRENT_LIST_DIR}/stamp
     DOWNLOAD_DIR         ""
     SOURCE_DIR           ${CMAKE_CURRENT_LIST_DIR}/src
+    BUILD_IN_SOURCE      False
     BINARY_DIR           ${CMAKE_CURRENT_LIST_DIR}/build
-    GIT_REPOSITORY       https://github.com/google/glog.git
+    GIT_REPOSITORY       ${DOWNLOAD_URL}
     GIT_TAG              v${PROJECT_VERSION}
     GIT_CONFIG           advice.detachedHead=false
     CMAKE_ARGS           -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=${3P_INSTALL_DIR}

--- a/third-party/googletest/CMakeLists.txt
+++ b/third-party/googletest/CMakeLists.txt
@@ -5,7 +5,13 @@ cmake_minimum_required(VERSION 3.12)
 
 project(GTEST_DOWNLOAD VERSION 1.10.0)
 
-message(STATUS "Downloading GoogleTest in ${CMAKE_CURRENT_LIST_DIR}.")
+if (EXISTS ${CMAKE_CURRENT_LIST_DIR}/src)
+    set(DOWNLOAD_URL)
+    message(STATUS "Found source code for GoogleTest in ${CMAKE_CURRENT_LIST_DIR}.")
+else()
+    message(STATUS "No source code found for GoogleTest; downloading in ${CMAKE_CURRENT_LIST_DIR}.")
+    set(DOWNLOAD_URL https://github.com/google/googletest.git)
+endif()
 
 include(ExternalProject)
 ExternalProject_Add(EP_GTEST
@@ -13,8 +19,9 @@ ExternalProject_Add(EP_GTEST
     STAMP_DIR            ${CMAKE_CURRENT_LIST_DIR}/stamp
     DOWNLOAD_DIR         ""
     SOURCE_DIR           ${CMAKE_CURRENT_LIST_DIR}/src
+    BUILD_IN_SOURCE      False
     BINARY_DIR           ${CMAKE_CURRENT_LIST_DIR}/build
-    GIT_REPOSITORY       https://github.com/google/googletest.git
+    GIT_REPOSITORY       ${DOWNLOAD_URL}
     GIT_TAG              release-${PROJECT_VERSION}
     GIT_CONFIG           advice.detachedHead=false
     CMAKE_ARGS           -DCMAKE_BUILD_TYPE=Release -DCMAKE_POSITION_INDEPENDENT_CODE=ON -DCMAKE_INSTALL_PREFIX=${3P_INSTALL_DIR}

--- a/third-party/protobuf/CMakeLists.txt
+++ b/third-party/protobuf/CMakeLists.txt
@@ -3,17 +3,25 @@
 
 cmake_minimum_required(VERSION 3.12)
 
-message(STATUS "Downloading Protobuf in ${CMAKE_CURRENT_LIST_DIR}.")
-
 project(PROTOBUF_DOWNLOAD VERSION 3.12.3)
+
+if (EXISTS ${CMAKE_CURRENT_LIST_DIR}/src)
+	set(DOWNLOAD_URL)
+	message(STATUS "Found source code for Protobuf in ${CMAKE_CURRENT_LIST_DIR}.")
+else()
+	message(STATUS "No source code found for Protobuf; downloading in ${CMAKE_CURRENT_LIST_DIR}.")
+	set(PROTOBUF_URL_SUFFIX "v${PROJECT_VERSION}/protobuf-cpp-${PROJECT_VERSION}.zip")
+	set(DOWNLOAD_URL https://github.com/google/protobuf/releases/download/${PROTOBUF_URL_SUFFIX})
+endif()
 
 # https://github.com/protocolbuffers/protobuf/tree/master/src
 include(ExternalProject)
-set(PROTOBUF_URL_SUFFIX "v${PROJECT_VERSION}/protobuf-cpp-${PROJECT_VERSION}.zip")
 ExternalProject_Add(EP_PROTOBUF
-    URL                  https://github.com/google/protobuf/releases/download/${PROTOBUF_URL_SUFFIX}
+    URL                  ${DOWNLOAD_URL}
     DOWNLOAD_DIR         ${CMAKE_CURRENT_LIST_DIR}
     SOURCE_DIR           ${CMAKE_CURRENT_LIST_DIR}/src
+    BUILD_IN_SOURCE      False
+    BINARY_DIR           ${CMAKE_CURRENT_LIST_DIR}/build
     SOURCE_SUBDIR        cmake
     CMAKE_ARGS           -DCMAKE_INSTALL_PREFIX=${3P_INSTALL_DIR}
     TEST_COMMAND         ""

--- a/third-party/seal/CMakeLists.txt
+++ b/third-party/seal/CMakeLists.txt
@@ -3,15 +3,23 @@
 
 cmake_minimum_required(VERSION 3.12)
 
-message(STATUS "Downloading Microsoft SEAL in ${CMAKE_CURRENT_LIST_DIR}.")
-
 project(SEAL_DOWNLOAD VERSION 3.6.1)
+
+if (EXISTS ${CMAKE_CURRENT_LIST_DIR}/src)
+	set(DOWNLOAD_URL)
+	message(STATUS "Found source code for Microsoft SEAL in ${CMAKE_CURRENT_LIST_DIR}.")
+else()
+	message(STATUS "No source code found for Microsoft SEAL; downloading in ${CMAKE_CURRENT_LIST_DIR}.")
+	set(DOWNLOAD_URL https://github.com/microsoft/SEAL/archive/v${PROJECT_VERSION}.zip)
+endif()
 
 include(ExternalProject)
 ExternalProject_Add(EP_SEAL
-    URL                  https://github.com/microsoft/SEAL/archive/v${PROJECT_VERSION}.zip
+    URL                  ${DOWNLOAD_URL}
     DOWNLOAD_DIR         ${CMAKE_CURRENT_LIST_DIR}
     SOURCE_DIR           ${CMAKE_CURRENT_LIST_DIR}/src
+    BUILD_IN_SOURCE      False
+    BINARY_DIR           ${CMAKE_CURRENT_LIST_DIR}/build
     CMAKE_ARGS           -DCMAKE_INSTALL_PREFIX=${3P_INSTALL_DIR}
     TEST_COMMAND         ""
 )

--- a/third-party/tbb/CMakeLists.txt
+++ b/third-party/tbb/CMakeLists.txt
@@ -3,15 +3,26 @@
 
 cmake_minimum_required(VERSION 3.12)
 
-message(STATUS "Downloading Intel TBB in ${CMAKE_CURRENT_LIST_DIR}.")
-
 project(TBB_DOWNLOAD VERSION 2021.1.1)
+
+# suppress a CMake warning about an unused variable
+set(SUPPRESS_VAR_WARNING ${3P_INSTALL_DIR})
+
+if (EXISTS ${CMAKE_CURRENT_LIST_DIR}/src)
+	set(DOWNLOAD_URL)
+	message(STATUS "Found source code for Intel TBB in ${CMAKE_CURRENT_LIST_DIR}.")
+else()
+	message(STATUS "No source code found for Intel TBB; downloading in ${CMAKE_CURRENT_LIST_DIR}.")
+	set(DOWNLOAD_URL https://github.com/oneapi-src/oneTBB/releases/download/v2020.3/tbb-2020.3-lin.tgz)
+endif()
 
 include(ExternalProject)
 ExternalProject_Add(EP_TBB
-	URL                  https://github.com/oneapi-src/oneTBB/releases/download/v2020.3/tbb-2020.3-lin.tgz
+    URL                  ${DOWNLOAD_URL}
     DOWNLOAD_DIR         ${CMAKE_CURRENT_LIST_DIR}
     SOURCE_DIR           ${CMAKE_CURRENT_LIST_DIR}/src
+    BUILD_IN_SOURCE      False
+    BINARY_DIR           ${CMAKE_CURRENT_LIST_DIR}/build
     CONFIGURE_COMMAND    ""
     BUILD_COMMAND        ""
     INSTALL_COMMAND      ""


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- My machine couldn't find GTest headers when building HIT, so I've made them explicit in the build system.
- SEAL caused problems when CMake was run successively without completely clearing out the SEAL build directory -- a tedious process not captured by our build system. I've fixed this problem by making `download-external-project` clear the dependency folder (except for `CMakeLists.txt`) automatically.
- While working on the build system, I hit a Github rate limit due to the number of times I was downloading dependencies. I was unable to build the library until I was no longer banned from accessing the download server. To fix this problem, I made three changes:
  - I ensured that all dependencies have an explicit out-of-source build. This means that the `<dependency>/src` folder should _only_ contain unpacked archives or a fresh github repo. Build's now happen in `<dependency>/build`.
  -  `download-external-project` also preserves the `src` folder.
  - Added a small amount of logic to the dependency build scripts so that if a `src` folder is found, they skip the download/unpack step of `Externalproject_add()`. This ensures that building multiple times won't download the dependency source multiple times. This appears to be working well from a build-reliability perspective, but if a user needs a "completely" fresh build they can just delete the `<dependency>/src` folder.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
