### PR TITLE
Fix a serialization bug and build system bug for debug mode

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,7 +15,7 @@ if (NOT CMAKE_BUILD_TYPE)
     set(CMAKE_BUILD_TYPE "Release" CACHE STRING "Build type" FORCE)
     set_property(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS "Release" "Debug" "MinSizeRel" "RelWithDebInfo")
 endif ()
-message(STATUS "Build type (CMAKE_BUILD_TYPE): ${CMAKE_BUILD_TYPE}")
+message(STATUS "HIT Build type (CMAKE_BUILD_TYPE): ${CMAKE_BUILD_TYPE}")
 
 #########
 # Paths #

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -9,8 +9,8 @@ add_library(aws_hit_obj OBJECT)
 add_dependencies(aws_hit_obj aws_hit_proto)
 
 # Disable parallelism in debug mode for easier debugging, especially with GDB
-if (CMAKE_BUILD_TYPE EQUAL "DEBUG")
-    target_compile_options(aws_hit_obj PRIVATE -DDISABLE_PARALLELISM)
+if (CMAKE_BUILD_TYPE STREQUAL "Debug")
+    target_compile_options(aws_hit_obj PUBLIC -DDISABLE_PARALLELISM)
 endif ()
 
 # Add source files to library and header files to install

--- a/src/hit/api/evaluator/homomorphic.cpp
+++ b/src/hit/api/evaluator/homomorphic.cpp
@@ -116,7 +116,7 @@ namespace hit {
         delete seal_decryptor;
     }
 
-    void HomomorphicEval::makeSealCtxt(EncryptionParameters params, timepoint start) {
+    void HomomorphicEval::makeSealCtxt(const seal::EncryptionParameters &params, const timepoint &start) {
         if (standard_params_) {
             context = make_unique<SEALContext>(params);
             print_elapsed_time(start, "Creating encryption context...");

--- a/src/hit/api/evaluator/homomorphic.cpp
+++ b/src/hit/api/evaluator/homomorphic.cpp
@@ -119,14 +119,13 @@ namespace hit {
     void HomomorphicEval::makeSealCtxt(const seal::EncryptionParameters &params, const timepoint &start) {
         if (standard_params_) {
             context = make_unique<SEALContext>(params);
-            print_elapsed_time(start, "Creating encryption context...");
         } else {
             LOG(WARNING) << "YOU ARE NOT USING STANDARD SEAL PARAMETERS. Encryption parameters may not achieve 128-bit security"
                          << "DO NOT USE IN PRODUCTION";
             // for large parameter sets, see https://github.com/microsoft/SEAL/issues/84
             context = make_unique<SEALContext>(params, true, sec_level_type::none);
-            print_elapsed_time(start, "Creating encryption context...");
         }
+        print_elapsed_time(start, "Creating encryption context...");
     }
 
     void HomomorphicEval::deserialize_common(istream &params_stream) {

--- a/src/hit/api/evaluator/homomorphic.cpp
+++ b/src/hit/api/evaluator/homomorphic.cpp
@@ -11,7 +11,6 @@
 
 #include <future>
 
-#include "../../common.h"
 #include "../../sealutils.h"
 #include "hit/protobuf/ckksparams.pb.h"
 
@@ -62,20 +61,10 @@ namespace hit {
         params.set_poly_modulus_degree(poly_modulus_degree);
         params.set_coeff_modulus(CoeffModulus::Create(poly_modulus_degree, modulusVector));
         timepoint start = chrono::steady_clock::now();
-        if (use_seal_params) {
-            context = make_unique<SEALContext>(params);
-            print_elapsed_time(start, "Creating encryption context...");
-            standard_params_ = true;
-        } else {
-            LOG(WARNING) << "YOU ARE NOT USING SEAL PARAMETERS. Encryption parameters may not achieve 128-bit security"
-                         << "DO NOT USE IN PRODUCTION";
-            // for large parameter sets, see https://github.com/microsoft/SEAL/issues/84
-            context = make_unique<SEALContext>(params, true, sec_level_type::none);
-            print_elapsed_time(start, "Creating encryption context...");
-            standard_params_ = false;
-        }
-        encoder = new CKKSEncoder(*context);
+        standard_params_ = use_seal_params;
+        makeSealCtxt(params, start);
         seal_evaluator = new Evaluator(*context);
+        encoder = new CKKSEncoder(*context);
 
         int num_galois_keys = galois_steps.size();
         VLOG(VLOG_VERBOSE) << "Generating keys for " << num_slots << " slots and depth " << multiplicative_depth
@@ -125,6 +114,19 @@ namespace hit {
         delete seal_evaluator;
         delete seal_encryptor;
         delete seal_decryptor;
+    }
+
+    void HomomorphicEval::makeSealCtxt(EncryptionParameters params, timepoint start) {
+        if (standard_params_) {
+            context = make_unique<SEALContext>(params);
+            print_elapsed_time(start, "Creating encryption context...");
+        } else {
+            LOG(WARNING) << "YOU ARE NOT USING STANDARD SEAL PARAMETERS. Encryption parameters may not achieve 128-bit security"
+                         << "DO NOT USE IN PRODUCTION";
+            // for large parameter sets, see https://github.com/microsoft/SEAL/issues/84
+            context = make_unique<SEALContext>(params, true, sec_level_type::none);
+            print_elapsed_time(start, "Creating encryption context...");
+        }
     }
 
     void HomomorphicEval::deserialize_common(istream &params_stream) {
@@ -181,16 +183,7 @@ namespace hit {
 
         standard_params_ = ckks_params.standardparams();
         timepoint start = chrono::steady_clock::now();
-        if (standard_params_) {
-            context = make_unique<SEALContext>(params);
-            print_elapsed_time(start, "Creating encryption context...");
-        } else {
-            LOG(WARNING) << "YOU ARE NOT USING SEAL PARAMETERS. Encryption parameters may not achieve 128-bit security."
-                         << " DO NOT USE IN PRODUCTION";
-            // for large parameter sets, see https://github.com/microsoft/SEAL/issues/84
-            context = make_unique<SEALContext>(params, true, sec_level_type::none);
-            print_elapsed_time(start, "Creating encryption context...");
-        }
+        makeSealCtxt(params, start);
         seal_evaluator = new Evaluator(*context);
         encoder = new CKKSEncoder(*context);
 

--- a/src/hit/api/evaluator/homomorphic.h
+++ b/src/hit/api/evaluator/homomorphic.h
@@ -7,6 +7,7 @@
 #include "../evaluator.h"
 #include "seal/context.h"
 #include "seal/seal.h"
+#include "../../common.h"
 
 namespace hit {
 
@@ -120,6 +121,7 @@ namespace hit {
         uint64_t get_last_prime_internal(const CKKSCiphertext &ct) const override;
 
         void deserialize_common(std::istream &params_stream);
+        void makeSealCtxt(seal::EncryptionParameters params, hit::timepoint start);
 
         friend class DebugEval;
         friend class ScaleEstimator;

--- a/src/hit/api/evaluator/homomorphic.h
+++ b/src/hit/api/evaluator/homomorphic.h
@@ -121,7 +121,7 @@ namespace hit {
         uint64_t get_last_prime_internal(const CKKSCiphertext &ct) const override;
 
         void deserialize_common(std::istream &params_stream);
-        void makeSealCtxt(seal::EncryptionParameters params, hit::timepoint start);
+        void makeSealCtxt(const seal::EncryptionParameters &params, const hit::timepoint &start);
 
         friend class DebugEval;
         friend class ScaleEstimator;

--- a/src/hit/api/linearalgebra/encryptedcolvector.cpp
+++ b/src/hit/api/linearalgebra/encryptedcolvector.cpp
@@ -20,6 +20,9 @@ namespace hit {
     void EncryptedColVector::read_from_proto(const shared_ptr<SEALContext> &context,
                                              const protobuf::EncryptedColVector &encrypted_col_vector) {
         height_ = encrypted_col_vector.height();
+        if (height_ == 0) {
+            return;
+        }
         unit = EncodingUnit(encrypted_col_vector.unit());
         cts.reserve(encrypted_col_vector.cts().cts_size());
         deserialize_vector(context, encrypted_col_vector.cts(), cts);

--- a/src/hit/api/linearalgebra/encryptedcolvector.cpp
+++ b/src/hit/api/linearalgebra/encryptedcolvector.cpp
@@ -20,6 +20,8 @@ namespace hit {
     void EncryptedColVector::read_from_proto(const shared_ptr<SEALContext> &context,
                                              const protobuf::EncryptedColVector &encrypted_col_vector) {
         height_ = encrypted_col_vector.height();
+        // if height is 0, this object is uninitialized. Don't call validate() (or create a unit):
+        // both will fail. Just return an uninitailzed object.
         if (height_ == 0) {
             return;
         }

--- a/src/hit/api/linearalgebra/encryptedmatrix.cpp
+++ b/src/hit/api/linearalgebra/encryptedmatrix.cpp
@@ -22,6 +22,8 @@ namespace hit {
                                           const protobuf::EncryptedMatrix &encrypted_matrix) {
         height_ = encrypted_matrix.height();
         width_ = encrypted_matrix.width();
+        // if height and width are 0, this object is uninitialized. Don't call validate() (or create a unit):
+        // both will fail. Just return an uninitailzed object.
         if (height_ == 0 && width_ == 0) {
             return;
         }

--- a/src/hit/api/linearalgebra/encryptedmatrix.cpp
+++ b/src/hit/api/linearalgebra/encryptedmatrix.cpp
@@ -22,8 +22,10 @@ namespace hit {
                                           const protobuf::EncryptedMatrix &encrypted_matrix) {
         height_ = encrypted_matrix.height();
         width_ = encrypted_matrix.width();
+        if (height_ == 0 && width_ == 0) {
+            return;
+        }
         unit = EncodingUnit(encrypted_matrix.unit());
-
         cts.reserve(encrypted_matrix.cts_size());
         for (int i = 0; i < encrypted_matrix.cts_size(); i++) {
             const protobuf::CiphertextVector &proto_ciphertext_vector = encrypted_matrix.cts(i);

--- a/src/hit/api/linearalgebra/encryptedrowvector.cpp
+++ b/src/hit/api/linearalgebra/encryptedrowvector.cpp
@@ -22,6 +22,9 @@ namespace hit {
     void EncryptedRowVector::read_from_proto(const shared_ptr<SEALContext> &context,
                                              const protobuf::EncryptedRowVector &encrypted_row_vector) {
         width_ = encrypted_row_vector.width();
+        if (width_ == 0) {
+            return;
+        }
         unit = EncodingUnit(encrypted_row_vector.unit());
         cts.reserve(encrypted_row_vector.cts().cts_size());
         deserialize_vector(context, encrypted_row_vector.cts(), cts);

--- a/src/hit/api/linearalgebra/encryptedrowvector.cpp
+++ b/src/hit/api/linearalgebra/encryptedrowvector.cpp
@@ -22,6 +22,8 @@ namespace hit {
     void EncryptedRowVector::read_from_proto(const shared_ptr<SEALContext> &context,
                                              const protobuf::EncryptedRowVector &encrypted_row_vector) {
         width_ = encrypted_row_vector.width();
+        // if width is 0, this object is uninitialized. Don't call validate() (or create a unit):
+        // both will fail. Just return an uninitailzed object.
         if (width_ == 0) {
             return;
         }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This fixes a few bugs and makes a few other minor improvements to output.
A full list of changes includes:
- Clarify the project name when describing the build type. It's hard to tell exactly which phase is being executed in CMake output; this clarifies the project.
- Fix a problem that prevented disabling parallelism when in debug mode. Debugging is hard when parallelism is active, so I previously added a flag to disable parallelism when `CMAKE_BUILD_TYPE` was Debug. However, there were several bugs in how this flag was activated, meaning that parallelism was still enabled in debug mode. The first bug was the case for the string `Debug` (was `DEBUG`). The second bug is that the flag needs to be `PUBLIC`, not `PRIVATE` so that projects that consume HIT but also import the header file have this macro defined. A possible third bug was the use of `EQUAL` instead of `STREQUAL`.
- I improved the warning message about not using SEAL parameters, and in the process noticed that this was duplicated. I refactored the code so that this (modified) string only appears once.
- I fixed a bug in the deserialization of linear algebra objects. Unintialized RowVectors, ColVectors, and Matrices can be created and serialized (by design), but deserialization was not handling the "unintialized" case correctly. Specifically, it was calling `validate()`, which will not pass for uninitialized objects. The bug was calling `validate()` when the input was unitialized.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
