### PR TITLE
Added bootstrapping APIs, but no implementations

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -16,6 +16,7 @@ Checks: >
   -bugprone-branch-clone,
   -google-readability-braces-around-statements,
   -google-readability-namespace-comments,
+  -google-readability-todo,
   -google-runtime-references,
   -misc-non-private-member-variables-in-classes,
   -modernize-return-braced-init-list,

--- a/README.md
+++ b/README.md
@@ -2,8 +2,6 @@
 
 HIT provides tools to simplify the process of designing homomorphic circuits for the CKKS homomorphic encryption scheme. This library is intended to further research in homomorphic encryption. Users must be aware of the security issues surrounding the deployment of CKKS homomorphic encryption; see SECURITY.md for details. This branch of the HIT repository uses the [Lattigo](https://github.com/ldsec/lattigo) homomorphic encryption library as a backend.
 
-TODO: Now with CKKS Bootstrapping!
-
 #### Build Status:
 * Ubuntu 18.04 GCC 9 ![Build Status](https://codebuild.us-west-2.amazonaws.com/badges?uuid=eyJlbmNyeXB0ZWREYXRhIjoiQ3Npc1hJQi9iQ0x0aHVlVW1EdERJZ1g0ZENhazl2b2ptMUkwTkgyS1pSRkVQNytDYUdPam9MS0VBeDc0ODlUNXRmaEVLaVZyaERna243d293aXRGRFVvPSIsIml2UGFyYW1ldGVyU3BlYyI6IkRqcnk0N08yQjRaTk8vS3IiLCJtYXRlcmlhbFNldFNlcmlhbCI6MX0%3D&branch=main)
 * Ubuntu 18.04 Clang 10 ![Build Status](https://codebuild.us-west-2.amazonaws.com/badges?uuid=eyJlbmNyeXB0ZWREYXRhIjoiKzFoQXZYbmppZW84SUFYWUhVYkVVSVZEaEtFYkVXL1J2MWtKUlBFTTJKY0d1d2MxSjBRNWtjRS91NE1PYjJ4QmIvck53aUQrZmMza2NBOTlTNW1ubTBBPSIsIml2UGFyYW1ldGVyU3BlYyI6IllTYS9GOGFqTS9FdmRmV3QiLCJtYXRlcmlhbFNldFNlcmlhbCI6MX0%3D&branch=main)

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 HIT provides tools to simplify the process of designing homomorphic circuits for the CKKS homomorphic encryption scheme. This library is intended to further research in homomorphic encryption. Users must be aware of the security issues surrounding the deployment of CKKS homomorphic encryption; see SECURITY.md for details. This branch of the HIT repository uses the [Lattigo](https://github.com/ldsec/lattigo) homomorphic encryption library as a backend.
 
+TODO: Now with CKKS Bootstrapping!
+
 #### Build Status:
 * Ubuntu 18.04 GCC 9 ![Build Status](https://codebuild.us-west-2.amazonaws.com/badges?uuid=eyJlbmNyeXB0ZWREYXRhIjoiQ3Npc1hJQi9iQ0x0aHVlVW1EdERJZ1g0ZENhazl2b2ptMUkwTkgyS1pSRkVQNytDYUdPam9MS0VBeDc0ODlUNXRmaEVLaVZyaERna243d293aXRGRFVvPSIsIml2UGFyYW1ldGVyU3BlYyI6IkRqcnk0N08yQjRaTk8vS3IiLCJtYXRlcmlhbFNldFNlcmlhbCI6MX0%3D&branch=main)
 * Ubuntu 18.04 Clang 10 ![Build Status](https://codebuild.us-west-2.amazonaws.com/badges?uuid=eyJlbmNyeXB0ZWREYXRhIjoiKzFoQXZYbmppZW84SUFYWUhVYkVVSVZEaEtFYkVXL1J2MWtKUlBFTTJKY0d1d2MxSjBRNWtjRS91NE1PYjJ4QmIvck53aUQrZmMza2NBOTlTNW1ubTBBPSIsIml2UGFyYW1ldGVyU3BlYyI6IllTYS9GOGFqTS9FdmRmV3QiLCJtYXRlcmlhbFNldFNlcmlhbCI6MX0%3D&branch=main)

--- a/src/hit/api/ciphertext.cpp
+++ b/src/hit/api/ciphertext.cpp
@@ -101,6 +101,10 @@ namespace hit {
         return needs_relin_;
     }
 
+    bool CKKSCiphertext::bootstrapped() const {
+        return bootstrapped_;
+    }
+
     vector<double> CKKSCiphertext::plaintext() const {
         if (raw_pt.empty()) {
             LOG_AND_THROW_STREAM("Ciphertext does not contain a plaintext.");

--- a/src/hit/api/ciphertext.h
+++ b/src/hit/api/ciphertext.h
@@ -36,6 +36,7 @@ namespace hit {
             num_slots_ = other.num_slots_;
             needs_relin_ = other.needs_relin_;
             needs_rescale_ = other.needs_rescale_;
+            bootstrapped_ = other.bootstrapped_;
         }
 
         // copy assignment operator
@@ -50,6 +51,7 @@ namespace hit {
                 num_slots_ = other.num_slots_;
                 needs_relin_ = other.needs_relin_;
                 needs_rescale_ = other.needs_rescale_;
+                bootstrapped_ = other.bootstrapped_;
             }
             return *this;
         }
@@ -69,6 +71,7 @@ namespace hit {
             num_slots_ = other.num_slots_;
             needs_relin_ = other.needs_relin_;
             needs_rescale_ = other.needs_rescale_;
+            bootstrapped_ = other.bootstrapped_;
         }
 
         // move assignment operator
@@ -83,6 +86,7 @@ namespace hit {
                 num_slots_ = other.num_slots_;
                 needs_relin_ = other.needs_relin_;
                 needs_rescale_ = other.needs_rescale_;
+                bootstrapped_ = other.bootstrapped_;
             }
             return *this;
         }
@@ -113,6 +117,8 @@ namespace hit {
         // Output true if the ciphertext is quadratic and is
         // therefore in need of relinearization, false otherwise.
         bool needs_relin() const override;
+        // Output true if bootstrapping was used in the computation of this ciphertext
+        bool bootstrapped() const override;
         std::vector<double> plaintext() const override;
 
         // all evaluators need access for encryption and decryption
@@ -129,7 +135,7 @@ namespace hit {
 
         double backend_scale() const;
 
-        // The raw plaintxt. This is used with some of the evaluators tha track ciphertext
+        // The raw plaintext. This is used with some of the evaluators tha track ciphertext
         // metadata (e.g., DebugEval and PlaintextEval), but not by the Homomorphic evaluator.
         // This plaintext is not CKKS-encoded; in particular it is not scaled by the scale factor.
         std::vector<double> raw_pt;
@@ -151,5 +157,6 @@ namespace hit {
 
         bool needs_relin_ = false;
         bool needs_rescale_ = false;
+        bool bootstrapped_ = false;
     };
 }  // namespace hit

--- a/src/hit/api/evaluator.h
+++ b/src/hit/api/evaluator.h
@@ -345,6 +345,10 @@ namespace hit {
          */
         void relinearize_inplace(CKKSCiphertext &ct);
 
+        /* TODO
+         */
+        CKKSCiphertext bootstrap(const CKKSCiphertext &ct, bool rescale_for_bootstrapping = true);
+
        protected:
         virtual void rotate_right_inplace_internal(CKKSCiphertext &ct, int steps);
         virtual void rotate_left_inplace_internal(CKKSCiphertext &ct, int steps);
@@ -364,6 +368,7 @@ namespace hit {
         virtual void relinearize_inplace_internal(CKKSCiphertext &ct);
         virtual void print_stats(const CKKSCiphertext &ct);
         virtual uint64_t get_last_prime_internal(const CKKSCiphertext &ct) const;
+        virtual CKKSCiphertext bootstrap_internal(const CKKSCiphertext &ct, bool rescale_for_bootstrapping);
 
         void reduce_metadata_to_level(CKKSCiphertext &ct, int level);
         void rescale_metata_to_next(CKKSCiphertext &ct);

--- a/src/hit/api/evaluator.h
+++ b/src/hit/api/evaluator.h
@@ -345,7 +345,17 @@ namespace hit {
          */
         void relinearize_inplace(CKKSCiphertext &ct);
 
-        /* TODO
+        /* Refresh a ciphertext at a low level (e.g., 0) to a ciphertext at a higher level. This
+         * enables the cryptosystem to continue to do work on a ciphertext. The exact level of the
+         * output is determined by the cryptosystem parameters. Lattigo has a restriction on the
+         * scale of the input ciphertext, namely, that if `ct.he_level() = 0`, then `ct.scale()`
+         * must be an exact power of two smaller or equal to round(Q0/2^{10}). If you know this
+         * condition is satisfied in your circuit, you can bootstrap directly, thereby allowing
+         * you to use the last ciphertext level for computation. If you are not sure,
+         * or if the ciphertext scale does not meet this requirement, the bootstrapping process can
+         * implicitly consume one extra level to rescale your ciphertext appropriately. If you know
+         * that rescaling is unnecessary, set `rescale_for_bootstrapping` to `false`, otherwise use
+         * the default value of `true`.
          */
         CKKSCiphertext bootstrap(const CKKSCiphertext &ct, bool rescale_for_bootstrapping = true);
 

--- a/src/hit/api/linearalgebra/encryptedcolvector.cpp
+++ b/src/hit/api/linearalgebra/encryptedcolvector.cpp
@@ -111,6 +111,10 @@ namespace hit {
         return decode_col_vector(plaintext_pieces, height_);
     }
 
+    bool EncryptedColVector::bootstrapped() const {
+        return cts[0].bootstrapped();
+    }
+
     void EncryptedColVector::validate() const {
         // validate the unit
         unit.validate();

--- a/src/hit/api/linearalgebra/encryptedcolvector.h
+++ b/src/hit/api/linearalgebra/encryptedcolvector.h
@@ -74,6 +74,8 @@ namespace hit {
         bool needs_relin() const override;
         // Underlying plaintext vector. This is only available with the Plaintext, Debug, and ScaleEstimator evaluators
         Vector plaintext() const override;
+        // Output true if the ciphertext has been bootstrapped
+        bool bootstrapped() const override;
 
        private:
         void read_from_proto(const std::shared_ptr<HEContext> &context,

--- a/src/hit/api/linearalgebra/encryptedmatrix.cpp
+++ b/src/hit/api/linearalgebra/encryptedmatrix.cpp
@@ -136,6 +136,10 @@ namespace hit {
         return decode_matrix(plaintext_pieces, height_, width_);
     }
 
+    bool EncryptedMatrix::bootstrapped() const {
+        return cts[0][0].bootstrapped();
+    }
+
     void EncryptedMatrix::validate() const {
         // validate the unit
         unit.validate();

--- a/src/hit/api/linearalgebra/encryptedmatrix.h
+++ b/src/hit/api/linearalgebra/encryptedmatrix.h
@@ -84,6 +84,8 @@ namespace hit {
         bool needs_relin() const override;
         // Underlying plaintext matrix. This is only available with the Plaintext, Debug, and ScaleEstimator evaluators
         Matrix plaintext() const override;
+        // Output true if the ciphertext has been bootstrapped
+        bool bootstrapped() const override;
 
        private:
         void read_from_proto(const std::shared_ptr<HEContext> &context,

--- a/src/hit/api/linearalgebra/encryptedrowvector.cpp
+++ b/src/hit/api/linearalgebra/encryptedrowvector.cpp
@@ -104,6 +104,10 @@ namespace hit {
         return decode_row_vector(plaintext_pieces, width_);
     }
 
+    bool EncryptedRowVector::bootstrapped() const {
+        return cts[0].bootstrapped();
+    }
+
     EncodingUnit EncryptedRowVector::encoding_unit() const {
         return unit;
     }

--- a/src/hit/api/linearalgebra/encryptedrowvector.h
+++ b/src/hit/api/linearalgebra/encryptedrowvector.h
@@ -90,6 +90,8 @@ namespace hit {
         bool needs_relin() const override;
         // Underlying plaintext vector. This is only available with the Plaintext, Debug, and ScaleEstimator evaluators
         Vector plaintext() const override;
+        // Output true if the ciphertext has been bootstrapped
+        bool bootstrapped() const override;
 
        private:
         void read_from_proto(const std::shared_ptr<HEContext> &context,

--- a/src/hit/api/metadata.h
+++ b/src/hit/api/metadata.h
@@ -30,6 +30,9 @@ namespace hit {
         // therefore in need of relinearization, false otherwise.
         virtual bool needs_relin() const = 0;
 
+        // Output true if the ciphertext has been bootstrapped
+        virtual bool bootstrapped() const = 0;
+
         virtual ~CiphertextMetadata<PlaintextType>() = default;
     };
 }  // namespace hit


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This is the first of several PRs to add bootstrapping to the Lattigo branch of HIT. This PR doesn't actually add any implementation of bootstrapping; rather it introduces some new APIs which will be implemented in future PRs. Specifically, it adds the `bootstrap()` API to the evaluator, and `bootstrapped()` to the metadata API. This latter API is useful to distinguish between encrypted objects which have and have not yet been bootstrapped, because there are a few differences between these states.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
