### PR TITLE
Added test for plaintext evaluator with bootstrapping

### DIFF
--- a/tests/api/evaluator/plaintext.cpp
+++ b/tests/api/evaluator/plaintext.cpp
@@ -262,3 +262,13 @@ TEST(PlaintextTest, Square) {
     ASSERT_NE(diff, INVALID_NORM);
     ASSERT_LE(diff, MAX_NORM);
 }
+
+TEST(PlaintextTest, Bootstrap) {
+    PlaintextEval ckks_instance = PlaintextEval(NUM_OF_SLOTS);
+    CKKSCiphertext ciphertext1, ciphertext2;
+    vector<double> vector1 = random_vector(NUM_OF_SLOTS, RANGE);
+    ciphertext1 = ckks_instance.encrypt(vector1);
+    ciphertext2 = ckks_instance.bootstrap(ciphertext1);
+    // should be identical
+    ASSERT_EQ(ciphertext1.plaintext(), ciphertext2.plaintext());
+}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This PR adds support for bootstrapping to the plaintext evaluator. Since bootstrapping doesn't do anything to a plaintext, we can use the default implementation of bootstrapping for the plaintext evaluator (inherited from the `CKKSEvaluator` API), and all we need to do is to add a unit test to ensure that bootstrapping is a no-op.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
