### PR TITLE
Add bootstrapping support to ScaleEstimator

### DIFF
--- a/src/hit/api/ciphertext.cpp
+++ b/src/hit/api/ciphertext.cpp
@@ -101,10 +101,6 @@ namespace hit {
         return needs_relin_;
     }
 
-    bool CKKSCiphertext::bootstrapped() const {
-        return bootstrapped_;
-    }
-
     vector<double> CKKSCiphertext::plaintext() const {
         if (raw_pt.empty()) {
             LOG_AND_THROW_STREAM("Ciphertext does not contain a plaintext.");

--- a/src/hit/api/ciphertext.h
+++ b/src/hit/api/ciphertext.h
@@ -117,8 +117,9 @@ namespace hit {
         // Output true if the ciphertext is quadratic and is
         // therefore in need of relinearization, false otherwise.
         bool needs_relin() const override;
-        // Output true if bootstrapping was used in the computation of this ciphertext
-        bool bootstrapped() const override;
+        // Output the plaintext included in this ciphertext, if it was encrypted with
+        // the Debug evaluator. The output is not a decrypted ciphertext, rather it is
+        // computed in-the-clear in parallel with the encrypted computation.
         std::vector<double> plaintext() const override;
 
         // all evaluators need access for encryption and decryption

--- a/src/hit/api/evaluator.cpp
+++ b/src/hit/api/evaluator.cpp
@@ -85,12 +85,12 @@ namespace hit {
             LOG_AND_THROW_STREAM("Inputs to add must have the same scale: " << log2(ct1.scale()) << " bits != "
                                                                             << log2(ct2.scale()) << " bits");
         }
-        if (ct1.bootstrapped() == ct2.bootstrapped() && ct1.he_level() != ct2.he_level()) {
+        if (ct1.bootstrapped_ == ct2.bootstrapped_ && ct1.he_level() != ct2.he_level()) {
             LOG_AND_THROW_STREAM("Inputs to add must be at the same level: " << ct1.he_level()
                                                                              << " != " << ct2.he_level());
         }
         add_inplace_internal(ct1, ct2);
-        ct1.bootstrapped_ |= ct2.bootstrapped();
+        ct1.bootstrapped_ |= ct2.bootstrapped_;
         print_stats(ct1);
     }
 
@@ -130,20 +130,20 @@ namespace hit {
         VLOG(VLOG_EVAL) << "Add ciphertext vector of size " << cts.size();
 
         CKKSCiphertext dest = cts[0];
-        bool bootstrapped = dest.bootstrapped();
+        bool bootstrapped_ = dest.bootstrapped_;
         for (int i = 1; i < cts.size(); i++) {
             if (cts[i].scale() != dest.scale()) {
                 LOG_AND_THROW_STREAM("Inputs to add_many must have the same scale: "
                                      << log2(cts[i].scale()) << " bits != " << log2(dest.scale()) << " bits");
             }
-            if (dest.bootstrapped() == cts[i].bootstrapped() && cts[i].he_level() != dest.he_level()) {
+            if (dest.bootstrapped_ == cts[i].bootstrapped_ && cts[i].he_level() != dest.he_level()) {
                 LOG_AND_THROW_STREAM("Inputs to add_many must be at the same level: " << cts[i].he_level()
                                                                                       << " != " << dest.he_level());
             }
-            bootstrapped |= cts[i].bootstrapped();
+            bootstrapped_ |= cts[i].bootstrapped_;
             add_inplace_internal(dest, cts[i]);
         }
-        dest.bootstrapped_ = bootstrapped;
+        dest.bootstrapped_ = bootstrapped_;
         print_stats(dest);
         return dest;
     }
@@ -160,12 +160,12 @@ namespace hit {
             LOG_AND_THROW_STREAM("Inputs to sub must have the same scale: " << log2(ct1.scale()) << " bits != "
                                                                             << log2(ct2.scale()) << " bits");
         }
-        if (ct1.bootstrapped() == ct2.bootstrapped() && ct1.he_level() != ct2.he_level()) {
+        if (ct1.bootstrapped_ == ct2.bootstrapped_ && ct1.he_level() != ct2.he_level()) {
             LOG_AND_THROW_STREAM("Inputs to sub must be at the same level: " << ct1.he_level()
                                                                              << " != " << ct2.he_level());
         }
         sub_inplace_internal(ct1, ct2);
-        ct1.bootstrapped_ |= ct2.bootstrapped();
+        ct1.bootstrapped_ |= ct2.bootstrapped_;
         print_stats(ct1);
     }
 
@@ -209,7 +209,7 @@ namespace hit {
         if (ct1.needs_relin() || ct2.needs_relin()) {
             LOG_AND_THROW_STREAM("Inputs to multiply must be linear ciphertexts");
         }
-        if (ct1.bootstrapped() == ct2.bootstrapped() && ct1.he_level() != ct2.he_level()) {
+        if (ct1.bootstrapped_ == ct2.bootstrapped_ && ct1.he_level() != ct2.he_level()) {
             LOG_AND_THROW_STREAM("Inputs to multiply must be at the same level: " << ct1.he_level()
                                                                                   << " != " << ct2.he_level());
         }
@@ -224,7 +224,7 @@ namespace hit {
         ct1.needs_rescale_ = true;
         ct1.needs_relin_ = true;
         ct1.scale_ *= ct1.scale_;
-        ct1.bootstrapped_ |= ct2.bootstrapped();
+        ct1.bootstrapped_ |= ct2.bootstrapped_;
         print_stats(ct1);
     }
 

--- a/src/hit/api/evaluator/explicitdepthfinder.cpp
+++ b/src/hit/api/evaluator/explicitdepthfinder.cpp
@@ -52,12 +52,12 @@ namespace hit {
     void ExplicitDepthFinder::set_explicit_post_bootstrap_depth(CKKSCiphertext &ct1, const CKKSCiphertext &ct2) {
         // This function only handles the case where the bootstrapped() status is different; the case where
         // they are the same is handled by CKKSEvaluator
-        if (ct1.bootstrapped() != ct2.bootstrapped()) {
+        if (ct1.bootstrapped_ != ct2.bootstrapped_) {
             scoped_lock lock(mutex_);
             // levels will not be aligned.
             // create references to the bootstrapped and non-bootstrapped (fresh) ciphertexts
-            const CKKSCiphertext &bootstrapped_ct = ct1.bootstrapped() ? ct1 : ct2;
-            const CKKSCiphertext &fresh_ct = ct1.bootstrapped() ? ct2 : ct1;
+            const CKKSCiphertext &bootstrapped_ct = ct1.bootstrapped_ ? ct1 : ct2;
+            const CKKSCiphertext &fresh_ct = ct1.bootstrapped_ ? ct2 : ct1;
 
             // An operation that combines a bootstrapped and non-bootstrapped ciphertext gives us
             // explicit information about how many levels are devoted to bootstrapping. A freshly
@@ -113,7 +113,7 @@ namespace hit {
          * already rescaled once after bootstrapping, and we are about to do so again. That means that
          * the post_bootstrap_depth is (at least) 2 = 1 - (-1).
          */
-        if (ct.bootstrapped()) {
+        if (ct.bootstrapped_) {
             scoped_lock lock(mutex_);
             implicit_post_bootstrap_depth_ = max(implicit_post_bootstrap_depth_, 1 - ct.he_level());
         }
@@ -130,7 +130,7 @@ namespace hit {
 
         // see comment in rescale_to_next_inplace_internal for explanation of arithmetic,
         // and note that rescale_for_bootstrapping is either 0 or 1.
-        if (ct.bootstrapped()) {
+        if (ct.bootstrapped_) {
             implicit_post_bootstrap_depth_ =
                 max(implicit_post_bootstrap_depth_, static_cast<int>(rescale_for_bootstrapping) - ct.he_level());
         }

--- a/src/hit/api/evaluator/homomorphic.h
+++ b/src/hit/api/evaluator/homomorphic.h
@@ -122,6 +122,7 @@ namespace hit {
         latticpp::RotationKeys galois_keys;
         latticpp::EvaluationKey relin_keys;
         bool standard_params_;
+        int btp_depth;
 
         latticpp::Evaluator &get_evaluator();
         latticpp::Encoder &get_encoder();

--- a/src/hit/api/evaluator/implicitdepthfinder.cpp
+++ b/src/hit/api/evaluator/implicitdepthfinder.cpp
@@ -43,12 +43,12 @@ namespace hit {
     // unequal. This function handles that case and ensures accurate tracking of the computation
     // depth in the presence of bootstrapping.
     void ImplicitDepthFinder::set_bootstrap_depth(CKKSCiphertext &ct1, const CKKSCiphertext &ct2) {
-        if (ct1.bootstrapped() != ct2.bootstrapped()) { 
+        if (ct1.bootstrapped_ != ct2.bootstrapped_) {
             scoped_lock lock(mutex_);
             // levels will not be aligned.
             // create references to the bootstrapped and non-bootstrapped (fresh) ciphertexts
-            const CKKSCiphertext &bootstrapped_ct = ct1.bootstrapped() ? ct1 : ct2;
-            const CKKSCiphertext &fresh_ct = ct1.bootstrapped() ? ct2 : ct1;
+            const CKKSCiphertext &bootstrapped_ct = ct1.bootstrapped_ ? ct1 : ct2;
+            const CKKSCiphertext &fresh_ct = ct1.bootstrapped_ ? ct2 : ct1;
 
             // An operation that combines a bootstrapped and non-bootstrapped ciphertext gives us
             // explicit information about how many levels are devoted to bootstrapping. A freshly
@@ -98,7 +98,7 @@ namespace hit {
          * Then zero minus a negative number is positive, which accurately tracks the computation depth.
          */
         scoped_lock lock(mutex_);
-        if (ct.bootstrapped()) {
+        if (ct.bootstrapped_) {
             post_bootstrap_depth_ = max(post_bootstrap_depth_, 1 - ct.he_level());
         } else {
             max_contiguous_depth = max(max_contiguous_depth, 1 - ct.he_level());
@@ -109,7 +109,7 @@ namespace hit {
     CKKSCiphertext ImplicitDepthFinder::bootstrap_internal(const CKKSCiphertext &ct, bool rescale_for_bootstrapping) {
         CKKSCiphertext bootstrapped_ct = ct;
         scoped_lock lock(mutex_);
-        if (ct.bootstrapped()) {
+        if (ct.bootstrapped_) {
             // this ciphertext has already been bootstrapped
             post_bootstrap_depth_ =
                 max(post_bootstrap_depth_, static_cast<int>(rescale_for_bootstrapping) - ct.he_level());

--- a/src/hit/api/evaluator/scaleestimator.cpp
+++ b/src/hit/api/evaluator/scaleestimator.cpp
@@ -36,7 +36,7 @@ namespace hit {
     }
 
     CKKSCiphertext ScaleEstimator::encrypt(const vector<double> &coeffs) {
-        return encrypt(coeffs, -1);
+        return encrypt(coeffs, context->max_ciphertext_level());
     }
 
     CKKSCiphertext ScaleEstimator::encrypt(const vector<double> &coeffs, int level) {
@@ -50,8 +50,8 @@ namespace hit {
                                  << " coefficients, but " << coeffs.size() << " were provided");
         }
 
-        if (level == -1) {
-            level = context->max_ciphertext_level();
+        if (level < 0) {
+            LOG_AND_THROW_STREAM("Encryption level must be non-negative; got " << level);
         }
 
         double scale = pow(2, context->log_scale());
@@ -236,6 +236,12 @@ namespace hit {
         // internal functions should not update the ciphertext metadata
         ct.he_level_ = input_level;
         ct.scale_ = input_scale;
+    }
+
+    CKKSCiphertext ScaleEstimator::bootstrap_internal(const CKKSCiphertext &ct, bool) {
+        CKKSCiphertext ctout = ct;
+        ctout.scale_ = pow(2, context->log_scale());
+        return ctout;
     }
 
     double ScaleEstimator::get_estimated_max_log_scale() const {

--- a/src/hit/api/evaluator/scaleestimator.cpp
+++ b/src/hit/api/evaluator/scaleestimator.cpp
@@ -18,7 +18,8 @@ namespace hit {
     // encoding/decoding, this should be set to as high as possible.
     int default_scale_bits = 30;
 
-    ScaleEstimator::ScaleEstimator(int num_slots, int multiplicative_depth) {
+    ScaleEstimator::ScaleEstimator(int num_slots, int multiplicative_depth, int bootstrapping_depth)
+        : btp_depth(bootstrapping_depth) {
         plaintext_eval = new PlaintextEval(num_slots);
 
         context = make_shared<HEContext>(HEContext(num_slots, multiplicative_depth, default_scale_bits));
@@ -29,6 +30,7 @@ namespace hit {
 
         // instead of creating a new instance, use the instance provided
         context = homom_eval.context;
+        btp_depth = homom_eval.btp_depth;
     }
 
     ScaleEstimator::~ScaleEstimator() {
@@ -241,6 +243,7 @@ namespace hit {
     CKKSCiphertext ScaleEstimator::bootstrap_internal(const CKKSCiphertext &ct, bool) {
         CKKSCiphertext ctout = ct;
         ctout.scale_ = pow(2, context->log_scale());
+        ctout.he_level_ = context->max_ciphertext_level() - btp_depth;
         return ctout;
     }
 

--- a/src/hit/api/evaluator/scaleestimator.h
+++ b/src/hit/api/evaluator/scaleestimator.h
@@ -23,10 +23,10 @@ namespace hit {
          * corresponding limit on the scale, and thus the precision, of the computation.
          * There's no good way to know what value to use here without generating some parameters
          * first. Reasonable values include 4096, 8192, or 16384.
-         * `multiplicative_depth` is the multiplicative depth of the circuit you wish to evaluate.
+         * `max_ct_level` is the maximum ciphertext level allowed by the HE parameters.
          * You can use the DepthFinder evaluator to compute this.
          */
-        ScaleEstimator(int num_slots, int multiplicative_depth, int bootstrapping_depth = 0);
+        ScaleEstimator(int num_slots, int max_ct_level, int bootstrapping_depth = 0);
 
         /* For documentation on the API, see ../evaluator.h */
         ~ScaleEstimator() override;

--- a/src/hit/api/evaluator/scaleestimator.h
+++ b/src/hit/api/evaluator/scaleestimator.h
@@ -80,6 +80,8 @@ namespace hit {
 
         void rescale_to_next_inplace_internal(CKKSCiphertext &ct) override;
 
+        CKKSCiphertext bootstrap_internal(const CKKSCiphertext &ct, bool rescale_for_bootstrapping) override;
+
        private:
         ScaleEstimator(int num_slots, const HomomorphicEval &homom_eval);
 

--- a/src/hit/api/evaluator/scaleestimator.h
+++ b/src/hit/api/evaluator/scaleestimator.h
@@ -26,7 +26,7 @@ namespace hit {
          * `multiplicative_depth` is the multiplicative depth of the circuit you wish to evaluate.
          * You can use the DepthFinder evaluator to compute this.
          */
-        ScaleEstimator(int num_slots, int multiplicative_depth);
+        ScaleEstimator(int num_slots, int multiplicative_depth, int bootstrapping_depth = 0);
 
         /* For documentation on the API, see ../evaluator.h */
         ~ScaleEstimator() override;
@@ -90,6 +90,7 @@ namespace hit {
         // If scale is too close to 60, SEAL throws the error "encoded values are too large" during encoding.
         // We set the estimated_max_log_scale to 59 to prevent this error.
         double estimated_max_log_scale_ = 59;
+        int btp_depth;
 
         // This helper function squares the scale of the input and then updates
         // the max_log_scale.

--- a/src/hit/api/linearalgebra/encryptedcolvector.cpp
+++ b/src/hit/api/linearalgebra/encryptedcolvector.cpp
@@ -111,10 +111,6 @@ namespace hit {
         return decode_col_vector(plaintext_pieces, height_);
     }
 
-    bool EncryptedColVector::bootstrapped() const {
-        return cts[0].bootstrapped();
-    }
-
     void EncryptedColVector::validate() const {
         // validate the unit
         unit.validate();

--- a/src/hit/api/linearalgebra/encryptedcolvector.h
+++ b/src/hit/api/linearalgebra/encryptedcolvector.h
@@ -74,8 +74,6 @@ namespace hit {
         bool needs_relin() const override;
         // Underlying plaintext vector. This is only available with the Plaintext, Debug, and ScaleEstimator evaluators
         Vector plaintext() const override;
-        // Output true if the ciphertext has been bootstrapped
-        bool bootstrapped() const override;
 
        private:
         void read_from_proto(const std::shared_ptr<HEContext> &context,

--- a/src/hit/api/linearalgebra/encryptedmatrix.cpp
+++ b/src/hit/api/linearalgebra/encryptedmatrix.cpp
@@ -136,10 +136,6 @@ namespace hit {
         return decode_matrix(plaintext_pieces, height_, width_);
     }
 
-    bool EncryptedMatrix::bootstrapped() const {
-        return cts[0][0].bootstrapped();
-    }
-
     void EncryptedMatrix::validate() const {
         // validate the unit
         unit.validate();

--- a/src/hit/api/linearalgebra/encryptedmatrix.h
+++ b/src/hit/api/linearalgebra/encryptedmatrix.h
@@ -84,8 +84,6 @@ namespace hit {
         bool needs_relin() const override;
         // Underlying plaintext matrix. This is only available with the Plaintext, Debug, and ScaleEstimator evaluators
         Matrix plaintext() const override;
-        // Output true if the ciphertext has been bootstrapped
-        bool bootstrapped() const override;
 
        private:
         void read_from_proto(const std::shared_ptr<HEContext> &context,

--- a/src/hit/api/linearalgebra/encryptedrowvector.cpp
+++ b/src/hit/api/linearalgebra/encryptedrowvector.cpp
@@ -104,10 +104,6 @@ namespace hit {
         return decode_row_vector(plaintext_pieces, width_);
     }
 
-    bool EncryptedRowVector::bootstrapped() const {
-        return cts[0].bootstrapped();
-    }
-
     EncodingUnit EncryptedRowVector::encoding_unit() const {
         return unit;
     }

--- a/src/hit/api/linearalgebra/encryptedrowvector.h
+++ b/src/hit/api/linearalgebra/encryptedrowvector.h
@@ -90,8 +90,6 @@ namespace hit {
         bool needs_relin() const override;
         // Underlying plaintext vector. This is only available with the Plaintext, Debug, and ScaleEstimator evaluators
         Vector plaintext() const override;
-        // Output true if the ciphertext has been bootstrapped
-        bool bootstrapped() const override;
 
        private:
         void read_from_proto(const std::shared_ptr<HEContext> &context,

--- a/src/hit/api/metadata.h
+++ b/src/hit/api/metadata.h
@@ -30,9 +30,6 @@ namespace hit {
         // therefore in need of relinearization, false otherwise.
         virtual bool needs_relin() const = 0;
 
-        // Output true if the ciphertext has been bootstrapped
-        virtual bool bootstrapped() const = 0;
-
         virtual ~CiphertextMetadata<PlaintextType>() = default;
     };
 }  // namespace hit

--- a/tests/api/evaluator/explicitdepthfinder.cpp
+++ b/tests/api/evaluator/explicitdepthfinder.cpp
@@ -50,12 +50,9 @@ TEST(ExplicitDepthFinderTest, Bootstrapping1) {
     // bootstrap. For this test, we make the bootstrapping depth 2, meaning
     // that post-bootstrapping, the ciphertext should be at level 1.
     CKKSCiphertext ciphertext2 = ckks_instance.bootstrap(ciphertext1, false);
-    ASSERT_EQ(true, ciphertext2.bootstrapped());
     ckks_instance.multiply_plain_inplace(ciphertext2, 1);
-    ASSERT_EQ(true, ciphertext2.bootstrapped());
     // reduce to level 0
     ckks_instance.rescale_to_next_inplace(ciphertext2);
-    ASSERT_EQ(true, ciphertext2.bootstrapped());
 
     ASSERT_EQ(1, ckks_instance.get_param_eval_depth());
     ASSERT_EQ(2, ckks_instance.get_param_bootstrap_depth());

--- a/tests/api/evaluator/scaleestimator.cpp
+++ b/tests/api/evaluator/scaleestimator.cpp
@@ -252,7 +252,7 @@ TEST(ScaleEstimatorTest, ReduceLevelToMin) {
 
 TEST(ScaleEstimatorTest, RescaleToNextInPlace) {
     ScaleEstimator ckks_instance = ScaleEstimator(NUM_OF_SLOTS, ONE_MULTI_DEPTH);
-    CKKSCiphertext ciphertext1, ciphertext2, ciphertext3;
+    CKKSCiphertext ciphertext1, ciphertext2;
     ciphertext1 = ckks_instance.encrypt(VECTOR_1);
     ciphertext2 = ckks_instance.square(ciphertext1);
     uint64_t prime = ckks_instance.context->get_qi(ciphertext2.he_level());
@@ -263,4 +263,24 @@ TEST(ScaleEstimatorTest, RescaleToNextInPlace) {
     // Expect estimatedMaxLogScale is changed.
     double estimatedMaxLogScale = PLAINTEXT_LOG_MAX - log2(VALUE * VALUE);
     ASSERT_EQ(estimatedMaxLogScale, ckks_instance.get_estimated_max_log_scale());
+}
+
+TEST(ScaleEstimatorTest, Bootstrap1) {
+    ScaleEstimator ckks_instance = ScaleEstimator(NUM_OF_SLOTS, TWO_MULTI_DEPTH, 1);
+    CKKSCiphertext ciphertext1, ciphertext2;
+    ciphertext1 = ckks_instance.encrypt(VECTOR_1);
+    ciphertext2 = ckks_instance.bootstrap(ciphertext1);
+    // Check scale.
+    ASSERT_EQ(pow(2, DEFAULT_LOG_SCALE), ciphertext2.scale());
+}
+
+TEST(ScaleEstimatorTest, Bootstrap2) {
+    ScaleEstimator ckks_instance = ScaleEstimator(NUM_OF_SLOTS, TWO_MULTI_DEPTH, 1);
+    CKKSCiphertext ciphertext1, ciphertext2, ciphertext3;
+    ciphertext1 = ckks_instance.encrypt(VECTOR_1);
+    ciphertext2 = ckks_instance.square(ciphertext1);
+    ckks_instance.rescale_to_next_inplace(ciphertext2);
+    ciphertext3 = ckks_instance.bootstrap(ciphertext2);
+    // Check scale.
+    ASSERT_EQ(pow(2, DEFAULT_LOG_SCALE), ciphertext3.scale());
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This PR adds bootstrapping support to the `ScaleEstimator` evaluator, with unit tests. It also removes the `bootstrapped()` API from metadata since this concept is useful for `DepthFinder`, but not well defined otherwise.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
