### PR TITLE
Replace thread_specific_ptr with object pool

### DIFF
--- a/src/hit/api/evaluator/debug.cpp
+++ b/src/hit/api/evaluator/debug.cpp
@@ -197,14 +197,14 @@ namespace hit {
             actual_debug_result << ">";
             LOG(ERROR) << actual_debug_result.str();
 
-            Encoder e = homomorphic_eval->get_encoder();
+            HomomorphicEval::PoolObject<Encoder> e = homomorphic_eval->get_encoder();
             cout << "PT log_inf norm: " << log2(l_inf_norm(ct.raw_pt)) << endl;
             cout << "log_scale: " << log2(ct.scale()) << endl;
             cout << "helevel: " << ct.he_level() << endl;
 
             Plaintext encoded_plain =
-                encodeNTTAtLvlNew(homomorphic_eval->context->params, e, ct.raw_pt, ct.he_level(), ct.scale());
-            vector<double> decoded_plain = ::decode(e, encoded_plain, log2(num_slots()));
+                encodeNTTAtLvlNew(homomorphic_eval->context->params, e.ref(), ct.raw_pt, ct.he_level(), ct.scale());
+            vector<double> decoded_plain = ::decode(e.ref(), encoded_plain, log2(num_slots()));
 
             // the exact_plaintext and homom_plaintext should have the same length.
             // decoded_plain is full-dimensional, however. This may not match


### PR DESCRIPTION
*Description of changes:*

Replace `thread_specific_ptr` (which can't be used with our reused worker threads) with object-pools.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
