### PR TITLE
Support bootstrapping serialization

### DIFF
--- a/protobuf/ckksparams.proto
+++ b/protobuf/ckksparams.proto
@@ -7,5 +7,5 @@ package hit.protobuf;
 message CKKSParams {
     required bytes ctx = 1;
     required bytes pubkey = 2;
-    required bool standardParams = 3;
+    optional bytes btp_params = 3;
 }

--- a/src/hit/api/evaluator/homomorphic.cpp
+++ b/src/hit/api/evaluator/homomorphic.cpp
@@ -144,8 +144,8 @@ namespace hit {
         }
 
         protobuf::CKKSParams ckks_params;
-
         ostringstream ctx_stream;
+
         marshalBinaryParameters(context->params, ctx_stream);
         ckks_params.set_ctx(ctx_stream.str());
 
@@ -158,7 +158,6 @@ namespace hit {
         ostringstream pk_stream;
         marshalBinaryPublicKey(pk, pk_stream);
         ckks_params.set_pubkey(pk_stream.str());
-
         ckks_params.SerializeToOstream(&params_stream);
 
         marshalBinaryRotationKeys(galois_keys, galois_key_stream);

--- a/src/hit/api/evaluator/homomorphic.cpp
+++ b/src/hit/api/evaluator/homomorphic.cpp
@@ -93,10 +93,6 @@ namespace hit {
         : HomomorphicEval(CKKSParams(num_slots, log_scale, max_ct_level), galois_steps) {
     }
 
-    HomomorphicEval::HomomorphicEval(int num_slots, int max_ct_level, int log_scale) :
-      // for now, we always use one key-switch prime
-      HomomorphicEval(CKKSParams(num_slots, log_scale, max_ct_level)) {}
-
     void HomomorphicEval::deserialize_common(istream &params_stream) {
         protobuf::CKKSParams ckks_params;
         ckks_params.ParseFromIstream(&params_stream);
@@ -360,18 +356,6 @@ namespace hit {
         bootstrapped_ct.backend_ct = latticpp::bootstrap(get_bootstrapper().ref(), ct.backend_ct);
         bootstrapped_ct.scale_ = pow(2, context->log_scale());
         bootstrapped_ct.he_level_ = context->max_ciphertext_level() - btp_depth;
-        return bootstrapped_ct;
-    }
-
-    CKKSCiphertext HomomorphicEval::bootstrap_internal(const CKKSCiphertext &ct, bool rescale_for_bootstrapping) {
-        if (rescale_for_bootstrapping && ct.he_level() == 0) {
-            LOG_AND_THROW_STREAM("Unable to bootstrap ciphertext at level 0 when rescale_for_bootstrapping is true.");
-        }
-
-        CKKSCiphertext bootstrapped_ct = ct;
-        bootstrapped_ct.backend_ct = latticpp::bootstrap(btp, ct.backend_ct);
-        ctout.scale_ = pow(2, context->log_scale());
-        ctout.he_level_ = context->max_ciphertext_level() - btp_depth;
         return bootstrapped_ct;
     }
 }  // namespace hit

--- a/src/hit/api/evaluator/homomorphic.cpp
+++ b/src/hit/api/evaluator/homomorphic.cpp
@@ -109,7 +109,7 @@ namespace hit {
             // make a context without support for bootstrapping
             context = make_shared<HEContext>(CKKSParams(params));
         }
-        
+
         istringstream pk_stream(ckks_params.pubkey());
         pk = unmarshalBinaryPublicKey(pk_stream);
     }
@@ -240,28 +240,20 @@ namespace hit {
      */
     HomomorphicEval::PoolObject<Evaluator> HomomorphicEval::get_evaluator() {
         std::optional<Evaluator> opt = backend_evaluator.poll();
-        Evaluator result =
-            opt.has_value()
-                ? std::move(*opt)
-                : newEvaluator(context->params, makeEvaluationKey(relin_keys, galois_keys));
+        Evaluator result = opt.has_value() ? std::move(*opt)
+                                           : newEvaluator(context->params, makeEvaluationKey(relin_keys, galois_keys));
         return PoolObject<Evaluator>(std::move(result), backend_evaluator);
     }
 
     HomomorphicEval::PoolObject<Encoder> HomomorphicEval::get_encoder() {
         std::optional<Encoder> opt = backend_encoder.poll();
-        Encoder result =
-            opt.has_value()
-                ? std::move(*opt)
-                : newEncoder(context->params);
+        Encoder result = opt.has_value() ? std::move(*opt) : newEncoder(context->params);
         return PoolObject<Encoder>(std::move(result), backend_encoder);
     }
 
     HomomorphicEval::PoolObject<Encryptor> HomomorphicEval::get_encryptor() {
         std::optional<Encryptor> opt = backend_encryptor.poll();
-        Encryptor result =
-            opt.has_value()
-                ? std::move(*opt)
-                : newEncryptorFromPk(context->params, pk);
+        Encryptor result = opt.has_value() ? std::move(*opt) : newEncryptorFromPk(context->params, pk);
         return PoolObject<Encryptor>(std::move(result), backend_encryptor);
     }
 
@@ -271,9 +263,7 @@ namespace hit {
         }
         std::optional<Bootstrapper> opt = backend_bootstrapper.poll();
         Bootstrapper result =
-            opt.has_value()
-                ? std::move(*opt)
-                : newBootstrapper(context->params, context->btp_params.value(), btp_keys);
+            opt.has_value() ? std::move(*opt) : newBootstrapper(context->params, context->btp_params.value(), btp_keys);
         return PoolObject<Bootstrapper>(std::move(result), backend_bootstrapper);
     }
 

--- a/src/hit/api/evaluator/homomorphic.cpp
+++ b/src/hit/api/evaluator/homomorphic.cpp
@@ -121,6 +121,9 @@ namespace hit {
         timepoint start = chrono::steady_clock::now();
         galois_keys = unmarshalBinaryRotationKeys(galois_key_stream);
         relin_keys = unmarshalBinaryRelinearizationKey(relin_key_stream);
+        if (context->btp_params.has_value()) {
+            btp_keys = makeBootstrappingKey(relin_keys, galois_keys);
+        }
         log_elapsed_time(start, "Reading keys...");
     }
 
@@ -133,6 +136,9 @@ namespace hit {
         sk = unmarshalBinarySecretKey(secret_key_stream);
         galois_keys = unmarshalBinaryRotationKeys(galois_key_stream);
         relin_keys = unmarshalBinaryRelinearizationKey(relin_key_stream);
+        if (context->btp_params.has_value()) {
+            btp_keys = makeBootstrappingKey(relin_keys, galois_keys);
+        }
         log_elapsed_time(start, "Reading keys...");
         backend_decryptor = newDecryptor(context->params, sk);
     }

--- a/src/hit/api/evaluator/homomorphic.cpp
+++ b/src/hit/api/evaluator/homomorphic.cpp
@@ -114,11 +114,8 @@ namespace hit {
         pk = unmarshalBinaryPublicKey(pk_stream);
     }
 
-    /* An evaluation instance */
-    HomomorphicEval::HomomorphicEval(istream &params_stream, istream &galois_key_stream, istream &relin_key_stream) {
-        deserialize_common(params_stream);
-
-        timepoint start = chrono::steady_clock::now();
+    void HomomorphicEval::deserializeEvalKeys(const timepoint &start, istream &galois_key_stream,
+                                              istream &relin_key_stream) {
         galois_keys = unmarshalBinaryRotationKeys(galois_key_stream);
         relin_keys = unmarshalBinaryRelinearizationKey(relin_key_stream);
         if (context->btp_params.has_value()) {
@@ -127,19 +124,20 @@ namespace hit {
         log_elapsed_time(start, "Reading keys...");
     }
 
+    /* An evaluation instance */
+    HomomorphicEval::HomomorphicEval(istream &params_stream, istream &galois_key_stream, istream &relin_key_stream) {
+        deserialize_common(params_stream);
+        timepoint start = chrono::steady_clock::now();
+        deserializeEvalKeys(start, galois_key_stream, relin_key_stream);
+    }
+
     /* A full instance */
     HomomorphicEval::HomomorphicEval(istream &params_stream, istream &galois_key_stream, istream &relin_key_stream,
                                      istream &secret_key_stream) {
         deserialize_common(params_stream);
-
         timepoint start = chrono::steady_clock::now();
         sk = unmarshalBinarySecretKey(secret_key_stream);
-        galois_keys = unmarshalBinaryRotationKeys(galois_key_stream);
-        relin_keys = unmarshalBinaryRelinearizationKey(relin_key_stream);
-        if (context->btp_params.has_value()) {
-            btp_keys = makeBootstrappingKey(relin_keys, galois_keys);
-        }
-        log_elapsed_time(start, "Reading keys...");
+        deserializeEvalKeys(start, galois_key_stream, relin_key_stream);
         backend_decryptor = newDecryptor(context->params, sk);
     }
 

--- a/src/hit/api/evaluator/homomorphic.cpp
+++ b/src/hit/api/evaluator/homomorphic.cpp
@@ -93,6 +93,10 @@ namespace hit {
         : HomomorphicEval(CKKSParams(num_slots, log_scale, max_ct_level), galois_steps) {
     }
 
+    HomomorphicEval::HomomorphicEval(int num_slots, int max_ct_level, int log_scale) :
+      // for now, we always use one key-switch prime
+      HomomorphicEval(CKKSParams(num_slots, log_scale, max_ct_level)) {}
+
     void HomomorphicEval::deserialize_common(istream &params_stream) {
         protobuf::CKKSParams ckks_params;
         ckks_params.ParseFromIstream(&params_stream);
@@ -366,10 +370,8 @@ namespace hit {
 
         CKKSCiphertext bootstrapped_ct = ct;
         bootstrapped_ct.backend_ct = latticpp::bootstrap(btp, ct.backend_ct);
-        // bootstrapped_ct.scale_ = ??
-        // bootstrapped_ct.he_level_ = post_bootstrap_lvl;
-        // bootstrapped_ct.needs_relin_ = ??
-        // bootstrapped_ct.needs_rescale_ = ??
+        ctout.scale_ = pow(2, context->log_scale());
+        ctout.he_level_ = context->max_ciphertext_level() - btp_depth;
         return bootstrapped_ct;
     }
 }  // namespace hit

--- a/src/hit/api/evaluator/homomorphic.cpp
+++ b/src/hit/api/evaluator/homomorphic.cpp
@@ -358,4 +358,18 @@ namespace hit {
         bootstrapped_ct.he_level_ = context->max_ciphertext_level() - btp_depth;
         return bootstrapped_ct;
     }
+
+    CKKSCiphertext HomomorphicEval::bootstrap_internal(const CKKSCiphertext &ct, bool rescale_for_bootstrapping) {
+        if (rescale_for_bootstrapping && ct.he_level() == 0) {
+            LOG_AND_THROW_STREAM("Unable to bootstrap ciphertext at level 0 when rescale_for_bootstrapping is true.");
+        }
+
+        CKKSCiphertext bootstrapped_ct = ct;
+        bootstrapped_ct.backend_ct = latticpp::bootstrap(btp, ct.backend_ct);
+        // bootstrapped_ct.scale_ = ??
+        // bootstrapped_ct.he_level_ = post_bootstrap_lvl;
+        // bootstrapped_ct.needs_relin_ = ??
+        // bootstrapped_ct.needs_rescale_ = ??
+        return bootstrapped_ct;
+    }
 }  // namespace hit

--- a/src/hit/api/evaluator/homomorphic.h
+++ b/src/hit/api/evaluator/homomorphic.h
@@ -107,51 +107,53 @@ namespace hit {
        private:
         template <typename T>
         class ObjectPool {
-            public:
-                std::optional<T> poll() {
-                    std::lock_guard<std::mutex> lock(pool_mutex);
-                    if (list.empty()) {
-                        return {};
-                    }
-                    T result = list.back();
-                    list.pop_back();
-                    return result;
+           public:
+            std::optional<T> poll() {
+                std::lock_guard<std::mutex> lock(pool_mutex);
+                if (list.empty()) {
+                    return {};
                 }
+                T result = list.back();
+                list.pop_back();
+                return result;
+            }
 
-                void offer(T &&object) {
-                    std::lock_guard<std::mutex> lock(pool_mutex);
-                    list.push_back(object);
-                }
-            private:
-                std::mutex pool_mutex;
-                std::deque<T> list;
+            void offer(T &&object) {
+                std::lock_guard<std::mutex> lock(pool_mutex);
+                list.push_back(object);
+            }
+
+           private:
+            std::mutex pool_mutex;
+            std::deque<T> list;
         };
 
         template <typename T>
         class PoolObject {
-            public:
-            PoolObject(T &&object, ObjectPool<T> &pool) : pool(pool), object(object) {}
+           public:
+            PoolObject(T &&object, ObjectPool<T> &pool) : pool(pool), object(object) {
+            }
             ~PoolObject() {
                 pool.offer(std::move(object));
             }
 
-            T* get() {
+            T *get() {
                 return &object;
             }
 
-            T* operator->() {
+            T *operator->() {
                 return get();
             }
 
-            T& ref() {
+            T &ref() {
                 return object;
             }
 
-            explicit operator T&() {
+            explicit operator T &() {
                 return ref();
             }
 
-            private:
+           private:
             ObjectPool<T> &pool;
             T object;
         };

--- a/src/hit/api/evaluator/homomorphic.h
+++ b/src/hit/api/evaluator/homomorphic.h
@@ -161,6 +161,7 @@ namespace hit {
         ObjectPool<latticpp::Encryptor> backend_encryptor;
         ObjectPool<latticpp::Bootstrapper> backend_bootstrapper;
         latticpp::Decryptor backend_decryptor;
+        latticpp::Bootstrapper btp;
         latticpp::PublicKey pk;
         latticpp::SecretKey sk;
         latticpp::RotationKeys galois_keys;

--- a/src/hit/api/evaluator/homomorphic.h
+++ b/src/hit/api/evaluator/homomorphic.h
@@ -166,7 +166,6 @@ namespace hit {
         latticpp::RotationKeys galois_keys;
         latticpp::RelinearizationKey relin_keys;
         latticpp::BootstrappingKey btp_keys;
-        bool standard_params_;
         int btp_depth = 0;
 
         PoolObject<latticpp::Evaluator> get_evaluator();

--- a/src/hit/api/evaluator/homomorphic.h
+++ b/src/hit/api/evaluator/homomorphic.h
@@ -161,7 +161,6 @@ namespace hit {
         ObjectPool<latticpp::Encryptor> backend_encryptor;
         ObjectPool<latticpp::Bootstrapper> backend_bootstrapper;
         latticpp::Decryptor backend_decryptor;
-        latticpp::Bootstrapper btp;
         latticpp::PublicKey pk;
         latticpp::SecretKey sk;
         latticpp::RotationKeys galois_keys;

--- a/src/hit/api/evaluator/homomorphic.h
+++ b/src/hit/api/evaluator/homomorphic.h
@@ -176,6 +176,8 @@ namespace hit {
         PoolObject<latticpp::Bootstrapper> get_bootstrapper();
 
         uint64_t get_last_prime_internal(const CKKSCiphertext &ct) const override;
+        void deserializeEvalKeys(const timepoint &start, std::istream &galois_key_stream,
+                                 std::istream &relin_key_stream);
 
         void deserialize_common(std::istream &params_stream);
 

--- a/src/hit/api/params.cpp
+++ b/src/hit/api/params.cpp
@@ -17,9 +17,8 @@ namespace hit {
     CKKSParams::CKKSParams(latticpp::Parameters lattigo_params) : lattigo_params(move(lattigo_params)) {
     }
 
-    CKKSParams::CKKSParams(const latticpp::BootstrappingParameters &lattigo_btp_params)
-        : lattigo_params(genParams(lattigo_btp_params)) {
-        btp_params = optional<BootstrappingParams>(BootstrappingParams(lattigo_btp_params));
+    CKKSParams::CKKSParams(latticpp::BootstrappingParameters lattigo_btp_params)
+        : CKKSParams(genParams(move(lattigo_btp_params)), move(lattigo_btp_params)) {
     }
 
     CKKSParams::CKKSParams(latticpp::Parameters lattigo_params, latticpp::BootstrappingParameters lattigo_btp_params)

--- a/src/hit/api/params.cpp
+++ b/src/hit/api/params.cpp
@@ -17,9 +17,8 @@ namespace hit {
     CKKSParams::CKKSParams(latticpp::Parameters params) : lattigo_params(move(params)) {
     }
 
-    CKKSParams::CKKSParams(latticpp::BootstrappingParameters btp_params)
-        : lattigo_params(genParams(btp_params)),
-          btp_params(optional<BootstrappingParams>(BootstrappingParams(move(btp_params)))) {
+    CKKSParams::CKKSParams(latticpp::BootstrappingParameters btp_params) : lattigo_params(genParams(btp_params)) {
+        btp_params = optional<BootstrappingParams>(BootstrappingParams(btp_params));
     }
 
     CKKSParams::CKKSParams(latticpp::Parameters lattigo_params, latticpp::BootstrappingParameters lattigo_btp_params)

--- a/src/hit/api/params.cpp
+++ b/src/hit/api/params.cpp
@@ -6,19 +6,19 @@
 using namespace std;
 
 namespace hit {
-    BootstrappingParams::BootstrappingParams(latticpp::BootstrappingParameters btp_params)
-        : lattigo_btp_params(move(btp_params)) {
+    BootstrappingParams::BootstrappingParams(latticpp::BootstrappingParameters lattigo_btp_params)
+        : lattigo_btp_params(move(lattigo_btp_params)) {
     }
 
     int BootstrappingParams::bootstrapping_depth() const {
         return bootstrapDepth(lattigo_btp_params);
     }
 
-    CKKSParams::CKKSParams(latticpp::Parameters params) : lattigo_params(move(params)) {
+    CKKSParams::CKKSParams(latticpp::Parameters lattigo_params) : lattigo_params(move(lattigo_params)) {
     }
 
-    CKKSParams::CKKSParams(latticpp::BootstrappingParameters btp_params) : lattigo_params(genParams(btp_params)) {
-        btp_params = optional<BootstrappingParams>(BootstrappingParams(btp_params));
+    CKKSParams::CKKSParams(const latticpp::BootstrappingParameters &lattigo_btp_params) : lattigo_params(genParams(lattigo_btp_params)) {
+        btp_params = optional<BootstrappingParams>(BootstrappingParams(lattigo_btp_params));
     }
 
     CKKSParams::CKKSParams(latticpp::Parameters lattigo_params, latticpp::BootstrappingParameters lattigo_btp_params)

--- a/src/hit/api/params.cpp
+++ b/src/hit/api/params.cpp
@@ -17,7 +17,8 @@ namespace hit {
     CKKSParams::CKKSParams(latticpp::Parameters lattigo_params) : lattigo_params(move(lattigo_params)) {
     }
 
-    CKKSParams::CKKSParams(const latticpp::BootstrappingParameters &lattigo_btp_params) : lattigo_params(genParams(lattigo_btp_params)) {
+    CKKSParams::CKKSParams(const latticpp::BootstrappingParameters &lattigo_btp_params)
+        : lattigo_params(genParams(lattigo_btp_params)) {
         btp_params = optional<BootstrappingParams>(BootstrappingParams(lattigo_btp_params));
     }
 

--- a/src/hit/api/params.h
+++ b/src/hit/api/params.h
@@ -104,8 +104,14 @@ namespace hit {
 
     class CKKSParams {
        public:
+        // Provide CKKS parameters without support for bootstrapping
         explicit CKKSParams(latticpp::Parameters params);
 
+        // Provide CKKS parameters and explicit bootstrapping parameters
+        // This is primarily used for serialization/deserialization
+        CKKSParams(latticpp::Parameters params, latticpp::BootstrappingParameters btp_params);
+
+        // Provide bootstrapping parameters and automatically generate suitable CKKS parameters
         explicit CKKSParams(latticpp::BootstrappingParameters btp_params);
 
         CKKSParams(latticpp::Parameters lattigo_params, latticpp::BootstrappingParameters lattigo_btp_params);

--- a/src/hit/api/params.h
+++ b/src/hit/api/params.h
@@ -108,7 +108,7 @@ namespace hit {
         explicit CKKSParams(latticpp::Parameters lattigo_params);
 
         // Provide bootstrapping parameters and automatically generate suitable CKKS parameters
-        explicit CKKSParams(const latticpp::BootstrappingParameters &lattigo_btp_params);
+        explicit CKKSParams(latticpp::BootstrappingParameters lattigo_btp_params);
 
         // Provide CKKS parameters and explicit bootstrapping parameters
         // This is primarily used for serialization/deserialization

--- a/src/hit/api/params.h
+++ b/src/hit/api/params.h
@@ -105,15 +105,13 @@ namespace hit {
     class CKKSParams {
        public:
         // Provide CKKS parameters without support for bootstrapping
-        explicit CKKSParams(latticpp::Parameters params);
+        explicit CKKSParams(latticpp::Parameters lattigo_params);
+
+        // Provide bootstrapping parameters and automatically generate suitable CKKS parameters
+        explicit CKKSParams(const latticpp::BootstrappingParameters &lattigo_btp_params);
 
         // Provide CKKS parameters and explicit bootstrapping parameters
         // This is primarily used for serialization/deserialization
-        CKKSParams(latticpp::Parameters params, latticpp::BootstrappingParameters btp_params);
-
-        // Provide bootstrapping parameters and automatically generate suitable CKKS parameters
-        explicit CKKSParams(latticpp::BootstrappingParameters btp_params);
-
         CKKSParams(latticpp::Parameters lattigo_params, latticpp::BootstrappingParameters lattigo_btp_params);
 
         CKKSParams(int num_slots, int log_scale, int max_ct_level, int num_ks_primes = 1,

--- a/tests/api/evaluator/homomorphic.cpp
+++ b/tests/api/evaluator/homomorphic.cpp
@@ -137,7 +137,7 @@ TEST(HomomorphicTest, Serialization_WithSecret_Bootstrapping) {
     ckks_instance2.relinearize_inplace(ciphertext);
     ckks_instance2.rescale_to_next_inplace(ciphertext);
     CKKSCiphertext bootstrapped_ct = ckks_instance2.bootstrap(ciphertext);
-    vector_output = ckks_instance2.decrypt(bootstrapped_ct);
+    vector<double> vector_output = ckks_instance2.decrypt(bootstrapped_ct);
 }
 
 TEST(HomomorphicTest, RotateLeft) {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Adds serialization of bootstrapping parameters. Note that clang-format also made a few changes. Will not pass CI until https://github.com/awslabs/aws-cppwrapper-lattigo/pull/8 is merged.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
