### PR TITLE
LinearAlgebra Encryption API

### DIFF
--- a/src/hit/api/evaluator/debug.cpp
+++ b/src/hit/api/evaluator/debug.cpp
@@ -110,10 +110,14 @@ namespace hit {
     }
 
     CKKSCiphertext DebugEval::encrypt(const vector<double> &coeffs) {
-        return encrypt(coeffs, -1);
+        return encrypt(coeffs, homomorphic_eval->context->max_ciphertext_level(););
     }
 
     CKKSCiphertext DebugEval::encrypt(const vector<double> &coeffs, int level) {
+        if (level < 0) {
+            LOG_AND_THROW_STREAM("Explicit encryption level must be non-negative, got " << level);
+        }
+
         scale_estimator->update_plaintext_max_val(coeffs);
         CKKSCiphertext destination = homomorphic_eval->encrypt(coeffs, level);
         destination.raw_pt = coeffs;

--- a/src/hit/api/evaluator/debug.cpp
+++ b/src/hit/api/evaluator/debug.cpp
@@ -110,7 +110,7 @@ namespace hit {
     }
 
     CKKSCiphertext DebugEval::encrypt(const vector<double> &coeffs) {
-        return encrypt(coeffs, homomorphic_eval->context->max_ciphertext_level(););
+        return encrypt(coeffs, homomorphic_eval->context->max_ciphertext_level());
     }
 
     CKKSCiphertext DebugEval::encrypt(const vector<double> &coeffs, int level) {

--- a/src/hit/api/evaluator/homomorphic.cpp
+++ b/src/hit/api/evaluator/homomorphic.cpp
@@ -169,7 +169,7 @@ namespace hit {
     }
 
     CKKSCiphertext HomomorphicEval::encrypt(const vector<double> &coeffs) {
-        return encrypt(coeffs, -1);
+        return encrypt(coeffs, context->max_ciphertext_level());
     }
 
     CKKSCiphertext HomomorphicEval::encrypt(const vector<double> &coeffs, int level) {
@@ -180,10 +180,6 @@ namespace hit {
             LOG_AND_THROW_STREAM("You can only encrypt vectors which have exactly as many "
                                  << " coefficients as the number of plaintext slots: Expected " << num_slots_
                                  << " coefficients, but " << coeffs.size() << " were provided");
-        }
-
-        if (level == -1) {
-            level = context->max_ciphertext_level();
         }
 
         double scale = pow(2, context->log_scale());

--- a/src/hit/api/evaluator/homomorphic.cpp
+++ b/src/hit/api/evaluator/homomorphic.cpp
@@ -184,7 +184,7 @@ namespace hit {
 
         double scale = pow(2, context->log_scale());
         // order of operations is very important: floating point arithmetic is not associative
-        for (int i = context->max_ciphertext_level(); i > level; i--) {
+        for (int i = context->max_ciphertext_level() - btp_depth; i > level; i--) {
             scale = (scale * scale) / static_cast<double>(context->get_qi(i));
         }
 

--- a/src/hit/api/evaluator/opcount.cpp
+++ b/src/hit/api/evaluator/opcount.cpp
@@ -22,10 +22,6 @@ namespace hit {
     }
 
     CKKSCiphertext OpCount::encrypt(const vector<double> &, int level) {
-        if (level < 0) {
-            LOG_AND_THROW_STREAM("Explicit encryption level must be non-negative, got " << level);
-        }
-
         {
             scoped_lock lock(mutex_);
             encryptions_++;

--- a/src/hit/api/evaluator/opcount.cpp
+++ b/src/hit/api/evaluator/opcount.cpp
@@ -17,10 +17,15 @@ namespace hit {
     }
 
     CKKSCiphertext OpCount::encrypt(const vector<double> &coeffs) {
-        return encrypt(coeffs, -1);
+        // ciphertext level doesn't matter for this evaluator
+        return encrypt(coeffs, 0);
     }
 
     CKKSCiphertext OpCount::encrypt(const vector<double> &, int level) {
+        if (level < 0) {
+            LOG_AND_THROW_STREAM("Explicit encryption level must be non-negative, got " << level);
+        }
+
         {
             scoped_lock lock(mutex_);
             encryptions_++;

--- a/src/hit/api/evaluator/plaintext.cpp
+++ b/src/hit/api/evaluator/plaintext.cpp
@@ -21,10 +21,14 @@ namespace hit {
     }
 
     CKKSCiphertext PlaintextEval::encrypt(const vector<double> &coeffs) {
-        return encrypt(coeffs, -1);
+        // ciphertext level doesn't matter for this evaluator
+        return encrypt(coeffs, 0);
     }
 
     CKKSCiphertext PlaintextEval::encrypt(const vector<double> &coeffs, int) {
+        if (level < 0) {
+            LOG_AND_THROW_STREAM("Explicit encryption level must be non-negative, got " << level);
+        }
         if (coeffs.size() != num_slots_) {
             // bad things can happen if you don't plan for your input to be smaller than the ciphertext
             // This forces the caller to ensure that the input has the correct size or is at least appropriately padded

--- a/src/hit/api/evaluator/plaintext.cpp
+++ b/src/hit/api/evaluator/plaintext.cpp
@@ -25,7 +25,7 @@ namespace hit {
         return encrypt(coeffs, 0);
     }
 
-    CKKSCiphertext PlaintextEval::encrypt(const vector<double> &coeffs, int) {
+    CKKSCiphertext PlaintextEval::encrypt(const vector<double> &coeffs, int level) {
         if (level < 0) {
             LOG_AND_THROW_STREAM("Explicit encryption level must be non-negative, got " << level);
         }

--- a/src/hit/api/evaluator/plaintext.cpp
+++ b/src/hit/api/evaluator/plaintext.cpp
@@ -25,10 +25,7 @@ namespace hit {
         return encrypt(coeffs, 0);
     }
 
-    CKKSCiphertext PlaintextEval::encrypt(const vector<double> &coeffs, int level) {
-        if (level < 0) {
-            LOG_AND_THROW_STREAM("Explicit encryption level must be non-negative, got " << level);
-        }
+    CKKSCiphertext PlaintextEval::encrypt(const vector<double> &coeffs, int) {
         if (coeffs.size() != num_slots_) {
             // bad things can happen if you don't plan for your input to be smaller than the ciphertext
             // This forces the caller to ensure that the input has the correct size or is at least appropriately padded

--- a/src/hit/api/evaluator/rotations.cpp
+++ b/src/hit/api/evaluator/rotations.cpp
@@ -22,9 +22,6 @@ namespace hit {
     }
 
     CKKSCiphertext RotationSet::encrypt(const vector<double> &, int level) {
-        if (level < 0) {
-            LOG_AND_THROW_STREAM("Explicit encryption level must be non-negative, got " << level);
-        }
         CKKSCiphertext destination;
         destination.he_level_ = level;
         destination.num_slots_ = num_slots_;

--- a/src/hit/api/evaluator/rotations.cpp
+++ b/src/hit/api/evaluator/rotations.cpp
@@ -17,10 +17,14 @@ namespace hit {
     }
 
     CKKSCiphertext RotationSet::encrypt(const vector<double> &coeffs) {
-        return encrypt(coeffs, -1);
+        // ciphertext level doesn't matter for this evaluator
+        return encrypt(coeffs, 0);
     }
 
     CKKSCiphertext RotationSet::encrypt(const vector<double> &, int level) {
+        if (level < 0) {
+            LOG_AND_THROW_STREAM("Explicit encryption level must be non-negative, got " << level);
+        }
         CKKSCiphertext destination;
         destination.he_level_ = level;
         destination.num_slots_ = num_slots_;

--- a/src/hit/api/evaluator/scaleestimator.cpp
+++ b/src/hit/api/evaluator/scaleestimator.cpp
@@ -47,6 +47,9 @@ namespace hit {
     }
 
     CKKSCiphertext ScaleEstimator::encrypt(const vector<double> &coeffs, int level) {
+        if (level < 0) {
+            LOG_AND_THROW_STREAM("Explicit encryption level must be non-negative; got " << level);
+        }
         update_plaintext_max_val(coeffs);
 
         if (coeffs.size() != context->num_slots()) {
@@ -55,10 +58,6 @@ namespace hit {
             LOG_AND_THROW_STREAM("You can only encrypt vectors which have exactly as many "
                                  << " coefficients as the number of plaintext slots: Expected " << context->num_slots()
                                  << " coefficients, but " << coeffs.size() << " were provided");
-        }
-
-        if (level < 0) {
-            LOG_AND_THROW_STREAM("Encryption level must be non-negative; got " << level);
         }
 
         double scale = pow(2, context->log_scale());

--- a/src/hit/api/linearalgebra/linearalgebra.cpp
+++ b/src/hit/api/linearalgebra/linearalgebra.cpp
@@ -106,8 +106,7 @@ namespace hit {
         return encrypt_row_vector_internal(vec, unit, lambda);
     }
 
-    EncryptedRowVector LinearAlgebra::encrypt_row_vector(const Vector &vec, const EncodingUnit &unit,
-                                                         int level) {
+    EncryptedRowVector LinearAlgebra::encrypt_row_vector(const Vector &vec, const EncodingUnit &unit, int level) {
         auto lambda = [&](CKKSEvaluator &eval_, const vector<double> &m) -> CKKSCiphertext {
             return eval_.encrypt(m, level);
         };
@@ -151,8 +150,7 @@ namespace hit {
         return encrypt_col_vector_internal(vec, unit, lambda);
     }
 
-    EncryptedColVector LinearAlgebra::encrypt_col_vector(const Vector &vec, const EncodingUnit &unit,
-                                                         int level) {
+    EncryptedColVector LinearAlgebra::encrypt_col_vector(const Vector &vec, const EncodingUnit &unit, int level) {
         auto lambda = [&](CKKSEvaluator &eval_, const vector<double> &m) -> CKKSCiphertext {
             return eval_.encrypt(m, level);
         };

--- a/src/hit/api/linearalgebra/linearalgebra.cpp
+++ b/src/hit/api/linearalgebra/linearalgebra.cpp
@@ -28,8 +28,9 @@ namespace hit {
         return encrypt_col_vector(vec, unit, level);
     }
 
-    EncryptedMatrix LinearAlgebra::encrypt_matrix_internal(const Matrix &mat, const EncodingUnit &unit,
-                                                           function<CKKSCiphertext(CKKSEvaluator &, const vector<double> &) > encrypt) { // NOLINT
+    EncryptedMatrix LinearAlgebra::encrypt_matrix_internal(
+        const Matrix &mat, const EncodingUnit &unit,
+        function<CKKSCiphertext(CKKSEvaluator &, const vector<double> &)> encrypt) {  // NOLINT
         vector<vector<Matrix>> mat_pieces = encode_matrix(mat, unit);
         vector<vector<CKKSCiphertext>> mat_cts(mat_pieces.size());
         for (int i = 0; i < mat_pieces.size(); i++) {
@@ -42,13 +43,15 @@ namespace hit {
         return EncryptedMatrix(mat.size1(), mat.size2(), unit, mat_cts);
     }
 
-    EncryptedMatrix LinearAlgebra::encrypt_matrix(const Matrix &mat, const EncodingUnit &unit) { // NOLINT
-        auto lambda = [](CKKSEvaluator &eval_, const vector<double> &m) ->CKKSCiphertext{ return eval_.encrypt(m); };
+    EncryptedMatrix LinearAlgebra::encrypt_matrix(const Matrix &mat, const EncodingUnit &unit) {
+        auto lambda = [](CKKSEvaluator &eval_, const vector<double> &m) -> CKKSCiphertext { return eval_.encrypt(m); };
         return encrypt_matrix_internal(mat, unit, lambda);
     }
 
-    EncryptedMatrix LinearAlgebra::encrypt_matrix(const Matrix &mat, const EncodingUnit &unit, int level) { // NOLINT
-        auto lambda = [&](CKKSEvaluator &eval_, const vector<double> &m) ->CKKSCiphertext{ return eval_.encrypt(m, level); };
+    EncryptedMatrix LinearAlgebra::encrypt_matrix(const Matrix &mat, const EncodingUnit &unit, int level) {
+        auto lambda = [&](CKKSEvaluator &eval_, const vector<double> &m) -> CKKSCiphertext {
+            return eval_.encrypt(m, level);
+        };
         return encrypt_matrix_internal(mat, unit, lambda);
     }
 
@@ -87,8 +90,9 @@ namespace hit {
         return "row " + to_string(arg.width()) + " (" + dim_string(arg.unit) + ")";
     }
 
-    EncryptedRowVector LinearAlgebra::encrypt_row_vector_internal(const Vector &vec, const EncodingUnit &unit,
-                                                                  function<CKKSCiphertext(CKKSEvaluator &, const vector<double> &) > encrypt) { // NOLINT
+    EncryptedRowVector LinearAlgebra::encrypt_row_vector_internal(
+        const Vector &vec, const EncodingUnit &unit,
+        function<CKKSCiphertext(CKKSEvaluator &, const vector<double> &)> encrypt) {  // NOLINT
         vector<Matrix> vec_pieces = encode_row_vector(vec, unit);
         vector<CKKSCiphertext> vec_cts(vec_pieces.size());
         for (int i = 0; i < vec_pieces.size(); i++) {
@@ -97,13 +101,16 @@ namespace hit {
         return EncryptedRowVector(vec.size(), unit, vec_cts);
     }
 
-    EncryptedRowVector LinearAlgebra::encrypt_row_vector(const Vector &vec, const EncodingUnit &unit) { // NOLINT
-        auto lambda = [](CKKSEvaluator &eval_, const vector<double> &m) ->CKKSCiphertext{ return eval_.encrypt(m); };
+    EncryptedRowVector LinearAlgebra::encrypt_row_vector(const Vector &vec, const EncodingUnit &unit) {
+        auto lambda = [](CKKSEvaluator &eval_, const vector<double> &m) -> CKKSCiphertext { return eval_.encrypt(m); };
         return encrypt_row_vector_internal(vec, unit, lambda);
     }
 
-    EncryptedRowVector LinearAlgebra::encrypt_row_vector(const Vector &vec, const EncodingUnit &unit, int level) { // NOLINT
-        auto lambda = [&](CKKSEvaluator &eval_, const vector<double> &m) ->CKKSCiphertext{ return eval_.encrypt(m, level); };
+    EncryptedRowVector LinearAlgebra::encrypt_row_vector(const Vector &vec, const EncodingUnit &unit,
+                                                         int level) {
+        auto lambda = [&](CKKSEvaluator &eval_, const vector<double> &m) -> CKKSCiphertext {
+            return eval_.encrypt(m, level);
+        };
         return encrypt_row_vector_internal(vec, unit, lambda);
     }
 
@@ -128,8 +135,9 @@ namespace hit {
         return "col " + to_string(arg.height()) + " (" + dim_string(arg.unit) + ")";
     }
 
-    EncryptedColVector LinearAlgebra::encrypt_col_vector_internal(const Vector &vec, const EncodingUnit &unit,
-                                                                  function<CKKSCiphertext(CKKSEvaluator &, const vector<double> &) > encrypt) { // NOLINT
+    EncryptedColVector LinearAlgebra::encrypt_col_vector_internal(
+        const Vector &vec, const EncodingUnit &unit,
+        function<CKKSCiphertext(CKKSEvaluator &, const vector<double> &)> encrypt) {  // NOLINT
         vector<Matrix> vec_pieces = encode_col_vector(vec, unit);
         vector<CKKSCiphertext> vec_cts(vec_pieces.size());
         for (int i = 0; i < vec_pieces.size(); i++) {
@@ -138,13 +146,16 @@ namespace hit {
         return EncryptedColVector(vec.size(), unit, vec_cts);
     }
 
-    EncryptedColVector LinearAlgebra::encrypt_col_vector(const Vector &vec, const EncodingUnit &unit) { // NOLINT
-        auto lambda = [](CKKSEvaluator &eval_, const vector<double> &m) ->CKKSCiphertext{ return eval_.encrypt(m); };
+    EncryptedColVector LinearAlgebra::encrypt_col_vector(const Vector &vec, const EncodingUnit &unit) {
+        auto lambda = [](CKKSEvaluator &eval_, const vector<double> &m) -> CKKSCiphertext { return eval_.encrypt(m); };
         return encrypt_col_vector_internal(vec, unit, lambda);
     }
 
-    EncryptedColVector LinearAlgebra::encrypt_col_vector(const Vector &vec, const EncodingUnit &unit, int level) { // NOLINT
-        auto lambda = [&](CKKSEvaluator &eval_, const vector<double> &m) ->CKKSCiphertext{ return eval_.encrypt(m, level); };
+    EncryptedColVector LinearAlgebra::encrypt_col_vector(const Vector &vec, const EncodingUnit &unit,
+                                                         int level) {
+        auto lambda = [&](CKKSEvaluator &eval_, const vector<double> &m) -> CKKSCiphertext {
+            return eval_.encrypt(m, level);
+        };
         return encrypt_col_vector_internal(vec, unit, lambda);
     }
 

--- a/src/hit/api/linearalgebra/linearalgebra.cpp
+++ b/src/hit/api/linearalgebra/linearalgebra.cpp
@@ -9,8 +9,18 @@ using namespace std;
 
 namespace hit {
     template <>
+    EncryptedRowVector LinearAlgebra::encrypt(const Vector &vec, const EncodingUnit &unit) {
+        return encrypt_row_vector(vec, unit);
+    }
+
+    template <>
     EncryptedRowVector LinearAlgebra::encrypt(const Vector &vec, const EncodingUnit &unit, int level) {
         return encrypt_row_vector(vec, unit, level);
+    }
+
+    template <>
+    EncryptedColVector LinearAlgebra::encrypt(const Vector &vec, const EncodingUnit &unit) {
+        return encrypt_col_vector(vec, unit);
     }
 
     template <>
@@ -18,17 +28,28 @@ namespace hit {
         return encrypt_col_vector(vec, unit, level);
     }
 
-    EncryptedMatrix LinearAlgebra::encrypt_matrix(const Matrix &mat, const EncodingUnit &unit, int level) {
+    EncryptedMatrix LinearAlgebra::encrypt_matrix_internal(const Matrix &mat, const EncodingUnit &unit,
+                                                           function<CKKSCiphertext(CKKSEvaluator &, const vector<double> &) > encrypt) { // NOLINT
         vector<vector<Matrix>> mat_pieces = encode_matrix(mat, unit);
         vector<vector<CKKSCiphertext>> mat_cts(mat_pieces.size());
         for (int i = 0; i < mat_pieces.size(); i++) {
             vector<CKKSCiphertext> row_cts(mat_pieces[0].size());
             for (int j = 0; j < mat_pieces[0].size(); j++) {
-                row_cts[j] = eval.encrypt(mat_pieces[i][j].data(), level);
+                row_cts[j] = encrypt(eval, mat_pieces[i][j].data());
             }
             mat_cts[i] = row_cts;
         }
         return EncryptedMatrix(mat.size1(), mat.size2(), unit, mat_cts);
+    }
+
+    EncryptedMatrix LinearAlgebra::encrypt_matrix(const Matrix &mat, const EncodingUnit &unit) { // NOLINT
+        auto lambda = [](CKKSEvaluator &eval_, const vector<double> &m) ->CKKSCiphertext{ return eval_.encrypt(m); };
+        return encrypt_matrix_internal(mat, unit, lambda);
+    }
+
+    EncryptedMatrix LinearAlgebra::encrypt_matrix(const Matrix &mat, const EncodingUnit &unit, int level) { // NOLINT
+        auto lambda = [&](CKKSEvaluator &eval_, const vector<double> &m) ->CKKSCiphertext{ return eval_.encrypt(m, level); };
+        return encrypt_matrix_internal(mat, unit, lambda);
     }
 
     Matrix LinearAlgebra::decrypt(const EncryptedMatrix &enc_mat, bool suppress_warnings) const {
@@ -66,13 +87,24 @@ namespace hit {
         return "row " + to_string(arg.width()) + " (" + dim_string(arg.unit) + ")";
     }
 
-    EncryptedRowVector LinearAlgebra::encrypt_row_vector(const Vector &vec, const EncodingUnit &unit, int level) {
+    EncryptedRowVector LinearAlgebra::encrypt_row_vector_internal(const Vector &vec, const EncodingUnit &unit,
+                                                                  function<CKKSCiphertext(CKKSEvaluator &, const vector<double> &) > encrypt) { // NOLINT
         vector<Matrix> vec_pieces = encode_row_vector(vec, unit);
         vector<CKKSCiphertext> vec_cts(vec_pieces.size());
         for (int i = 0; i < vec_pieces.size(); i++) {
-            vec_cts[i] = eval.encrypt(vec_pieces[i].data(), level);
+            vec_cts[i] = encrypt(eval, vec_pieces[i].data());
         }
         return EncryptedRowVector(vec.size(), unit, vec_cts);
+    }
+
+    EncryptedRowVector LinearAlgebra::encrypt_row_vector(const Vector &vec, const EncodingUnit &unit) { // NOLINT
+        auto lambda = [](CKKSEvaluator &eval_, const vector<double> &m) ->CKKSCiphertext{ return eval_.encrypt(m); };
+        return encrypt_row_vector_internal(vec, unit, lambda);
+    }
+
+    EncryptedRowVector LinearAlgebra::encrypt_row_vector(const Vector &vec, const EncodingUnit &unit, int level) { // NOLINT
+        auto lambda = [&](CKKSEvaluator &eval_, const vector<double> &m) ->CKKSCiphertext{ return eval_.encrypt(m, level); };
+        return encrypt_row_vector_internal(vec, unit, lambda);
     }
 
     Vector LinearAlgebra::decrypt(const EncryptedRowVector &enc_vec, bool suppress_warnings) const {
@@ -96,13 +128,24 @@ namespace hit {
         return "col " + to_string(arg.height()) + " (" + dim_string(arg.unit) + ")";
     }
 
-    EncryptedColVector LinearAlgebra::encrypt_col_vector(const Vector &vec, const EncodingUnit &unit, int level) {
+    EncryptedColVector LinearAlgebra::encrypt_col_vector_internal(const Vector &vec, const EncodingUnit &unit,
+                                                                  function<CKKSCiphertext(CKKSEvaluator &, const vector<double> &) > encrypt) { // NOLINT
         vector<Matrix> vec_pieces = encode_col_vector(vec, unit);
         vector<CKKSCiphertext> vec_cts(vec_pieces.size());
         for (int i = 0; i < vec_pieces.size(); i++) {
-            vec_cts[i] = eval.encrypt(vec_pieces[i].data(), level);
+            vec_cts[i] = encrypt(eval, vec_pieces[i].data());
         }
         return EncryptedColVector(vec.size(), unit, vec_cts);
+    }
+
+    EncryptedColVector LinearAlgebra::encrypt_col_vector(const Vector &vec, const EncodingUnit &unit) { // NOLINT
+        auto lambda = [](CKKSEvaluator &eval_, const vector<double> &m) ->CKKSCiphertext{ return eval_.encrypt(m); };
+        return encrypt_col_vector_internal(vec, unit, lambda);
+    }
+
+    EncryptedColVector LinearAlgebra::encrypt_col_vector(const Vector &vec, const EncodingUnit &unit, int level) { // NOLINT
+        auto lambda = [&](CKKSEvaluator &eval_, const vector<double> &m) ->CKKSCiphertext{ return eval_.encrypt(m, level); };
+        return encrypt_col_vector_internal(vec, unit, lambda);
     }
 
     EncodingUnit LinearAlgebra::make_unit(int encoding_height) const {

--- a/src/hit/api/linearalgebra/linearalgebra.h
+++ b/src/hit/api/linearalgebra/linearalgebra.h
@@ -75,11 +75,17 @@ namespace hit {
         EncodingUnit make_unit(int encoding_height) const;
 
         /* Encrypt a matrix after encoding it with the provided encoding unit.
-         * Matrix is encrypted at the specified level, or at the highest level allowed by the
-         * encryption parameters if no level is specified. We encode the matrix
+         * Matrix is encrypted at the highest level allowed by the
+         * encryption parameters. We encode the matrix
          * as described in encryptedmatrix.h.
          */
-        EncryptedMatrix encrypt_matrix(const Matrix &mat, const EncodingUnit &unit, int level = -1);
+        EncryptedMatrix encrypt_matrix(const Matrix &mat, const EncodingUnit &unit);
+
+        /* Encrypt a matrix after encoding it with the provided encoding unit.
+         * Matrix is encrypted at the specified level. We encode the matrix
+         * as described in encryptedmatrix.h.
+         */
+        EncryptedMatrix encrypt_matrix(const Matrix &mat, const EncodingUnit &unit, int level);
 
         /* Decrypt a matrix with any ciphertext degree and any scale.
          * This function will log a message if you try to decrypt a ciphertext which
@@ -88,9 +94,15 @@ namespace hit {
          */
         Matrix decrypt(const EncryptedMatrix &enc_mat, bool suppress_warnings = false) const;
 
-        /* Uniform encryption API, identical to encrypt_matrix
+        /* Uniform encryption API, identical to encrypt_matrix with no level
          */
-        EncryptedMatrix encrypt(const Matrix &mat, const EncodingUnit &unit, int level = -1) {
+        EncryptedMatrix encrypt(const Matrix &mat, const EncodingUnit &unit) {
+            return encrypt_matrix(mat, unit);
+        }
+
+        /* Uniform encryption API, identical to encrypt_matrix with explicit level
+         */
+        EncryptedMatrix encrypt(const Matrix &mat, const EncodingUnit &unit, int level) {
             return encrypt_matrix(mat, unit, level);
         }
 
@@ -99,13 +111,26 @@ namespace hit {
          * Template parameter must be explicitly specified.
          */
         template <typename T>
-        T encrypt(const Vector &, const EncodingUnit &, int level = -1);
+        T encrypt(const Vector &, const EncodingUnit &);
+
+        /* Uniform encryption API, defined for T=EncryptedRowVector and T=EncryptedColVector,
+         * exactly corresponding to `encrypt_row_vector` and `encrypt_col_vector`, respectively.
+         * Template parameter must be explicitly specified.
+         */
+        template <typename T>
+        T encrypt(const Vector &, const EncodingUnit &, int level);
 
         /* Encrypt a vector representing a linear algebra row vector.
          * We first encode the vector as a matrix
          * where each column is `vec`; see encryptedrowvector.h for details.
          */
-        EncryptedRowVector encrypt_row_vector(const Vector &vec, const EncodingUnit &unit, int level = -1);
+        EncryptedRowVector encrypt_row_vector(const Vector &vec, const EncodingUnit &unit);
+
+        /* Encrypt a vector representing a linear algebra row vector.
+         * We first encode the vector as a matrix
+         * where each column is `vec`; see encryptedrowvector.h for details.
+         */
+        EncryptedRowVector encrypt_row_vector(const Vector &vec, const EncodingUnit &unit, int level);
 
         /* Decrypt a row vector with any ciphertext degree and any scale.
          * This function will log a message if you try to decrypt a ciphertext which
@@ -118,7 +143,13 @@ namespace hit {
          * We first encode the vector as a matrix
          * where each row is `vec`; see encryptedcolvector.h for details.
          */
-        EncryptedColVector encrypt_col_vector(const Vector &vec, const EncodingUnit &unit, int level = -1);
+        EncryptedColVector encrypt_col_vector(const Vector &vec, const EncodingUnit &unit);
+
+        /* Encrypt a vector representing a linear algebra column vector.
+         * We first encode the vector as a matrix
+         * where each row is `vec`; see encryptedcolvector.h for details.
+         */
+        EncryptedColVector encrypt_col_vector(const Vector &vec, const EncodingUnit &unit, int level);
 
         /* Decrypt a column vector with any ciphertext degree and any scale.
          * This function will log a message if you try to decrypt a ciphertext which
@@ -1118,6 +1149,14 @@ namespace hit {
        private:
         template <typename T>
         std::string dim_string(const T &arg);
+        EncryptedMatrix encrypt_matrix_internal(const Matrix &mat, const EncodingUnit &unit,
+                        std::function<CKKSCiphertext(CKKSEvaluator &, const std::vector<double>&)> encrypt);
+
+        EncryptedRowVector encrypt_row_vector_internal(const Vector &vec, const EncodingUnit &unit,
+                           std::function<CKKSCiphertext(CKKSEvaluator &, const std::vector<double> &) > encrypt);
+
+        EncryptedColVector encrypt_col_vector_internal(const Vector &vec, const EncodingUnit &unit,
+                           std::function<CKKSCiphertext(CKKSEvaluator &, const std::vector<double> &) > encrypt);
 
         // helper function for validating inputs to matrix-matrix multiplication
         void matrix_multiply_validation(const EncryptedMatrix &enc_mat_a, const EncryptedMatrix &enc_mat_b,

--- a/src/hit/api/linearalgebra/linearalgebra.h
+++ b/src/hit/api/linearalgebra/linearalgebra.h
@@ -1149,14 +1149,17 @@ namespace hit {
        private:
         template <typename T>
         std::string dim_string(const T &arg);
-        EncryptedMatrix encrypt_matrix_internal(const Matrix &mat, const EncodingUnit &unit,
-                        std::function<CKKSCiphertext(CKKSEvaluator &, const std::vector<double>&)> encrypt);
+        EncryptedMatrix encrypt_matrix_internal(
+            const Matrix &mat, const EncodingUnit &unit,
+            std::function<CKKSCiphertext(CKKSEvaluator &, const std::vector<double> &)> encrypt);
 
-        EncryptedRowVector encrypt_row_vector_internal(const Vector &vec, const EncodingUnit &unit,
-                           std::function<CKKSCiphertext(CKKSEvaluator &, const std::vector<double> &) > encrypt);
+        EncryptedRowVector encrypt_row_vector_internal(
+            const Vector &vec, const EncodingUnit &unit,
+            std::function<CKKSCiphertext(CKKSEvaluator &, const std::vector<double> &)> encrypt);
 
-        EncryptedColVector encrypt_col_vector_internal(const Vector &vec, const EncodingUnit &unit,
-                           std::function<CKKSCiphertext(CKKSEvaluator &, const std::vector<double> &) > encrypt);
+        EncryptedColVector encrypt_col_vector_internal(
+            const Vector &vec, const EncodingUnit &unit,
+            std::function<CKKSCiphertext(CKKSEvaluator &, const std::vector<double> &)> encrypt);
 
         // helper function for validating inputs to matrix-matrix multiplication
         void matrix_multiply_validation(const EncryptedMatrix &enc_mat_a, const EncryptedMatrix &enc_mat_b,


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This PR updates the encryption API for LinearAlgebra, which is needed because the implicit encryption API of `ExplicitDepthFinder` expects non-negative encryption levels, while the LinearAlgebra API passes in `-1`. 

This wasn't detected earlier because other evaluators don't explicitly check that the encryption level is non-negative. This PR adds this check to other evaluators that track circuit depth to ensure a consistent API. I also changed how the base evaluators handle implicit encryption levels to avoid ever passing in the level "-1" to the explicit-level encryption API.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
