### PR TITLE
Prep for 0.0.2 release and fix cmake warning

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@
 
 cmake_minimum_required(VERSION 3.12)
 
-project(homomorphic-implementors-toolkit VERSION 0.0.1 LANGUAGES CXX)
+project(homomorphic-implementors-toolkit VERSION 0.0.2 LANGUAGES CXX)
 
 #################
 # CMAKE OPTIONS #
@@ -136,7 +136,7 @@ export(
     NAMESPACE hit::
     FILE ${HIT_TARGETS_FILENAME})
 
-export(TARGETS aws-hit FILE ${HIT_TARGETS_FILENAME})
+export(TARGETS aws-hit APPEND FILE ${HIT_TARGETS_FILENAME})
 
 #########
 # Tests #


### PR DESCRIPTION
Prep for 0.0.2 release and fix cmake warning

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
