### PR TITLE
Change how ciphertext primes are generated to prevent scale divergence

### DIFF
--- a/src/hit/api/params.cpp
+++ b/src/hit/api/params.cpp
@@ -7,13 +7,13 @@
 
 using namespace std;
 using namespace seal;
-// using namespace boost::random;
 using namespace boost::multiprecision;
 
 namespace hit {
 
-    // This is _not_ adversarial prime generation. If we accidentally generate a composite,
-    // the math is just wrong.
+    // This is _not_ adversarial prime generation. The primes will be public, and security is based on
+    // the total bit size of the _product_ of each "prime", so there are no security implications if
+    // we accidentally generate a composite.
     int miller_rabin_iters = 25;
 
     // true if x \in mods, false otherwise
@@ -98,7 +98,6 @@ namespace hit {
         int poly_modulus_degree = num_slots * 2;
         params.set_poly_modulus_degree(poly_modulus_degree);
         vector<int> modulus_vec = gen_modulus_vec(max_ct_level + 2, log_scale);
-        // vector<Modulus> mods = CoeffModulus::Create(poly_modulus_degree, modulus_vec);
         vector<Modulus> mods = reducedErrorPrimes(poly_modulus_degree, modulus_vec);
         params.set_coeff_modulus(mods);
     }

--- a/src/hit/api/params.cpp
+++ b/src/hit/api/params.cpp
@@ -3,10 +3,91 @@
 
 #include "params.h"
 
+#include <boost/multiprecision/miller_rabin.hpp>
+
 using namespace std;
 using namespace seal;
+// using namespace boost::random;
+using namespace boost::multiprecision;
 
 namespace hit {
+
+    // This is _not_ adversarial prime generation. If we accidentally generate a composite,
+    // the math is just wrong.
+    int miller_rabin_iters = 25;
+
+    // true if x \in mods, false otherwise
+    bool contains(uint64_t x, const vector<Modulus> &mods) {
+        for (const auto &m : mods) {
+            if (x == m.value()) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    // return the representative of x mod n in (-n/2, n/2]
+    uint64_t repr(uint64_t x, uint64_t n) {
+        uint64_t cmod = x % n;
+        return (cmod <= (n / 2)) ? cmod : (cmod - n);
+    }
+
+    // return the closest integer to x such that x = 1 mod n
+    uint64_t to1Coset(uint64_t x, uint64_t n) {
+        // note that n is always even in our uses case.
+        // if x <= kn+n/2 (for some k), then repr(x,n) > 0,
+        //   so we return kn+1, which is closer than (k+1)n+1.
+        // if x > kn+n/2 (for some k), then repr(x,n) < 0,
+        //   so we return (k+1)n+1, which is at least as close as kn+1.
+        return x - repr(x, n) + 1;
+    }
+
+    uint64_t nextPrime(uint64_t last_prime, uint64_t two_n, const vector<Modulus> &mods) {
+        // get the closest prime to `last_prime` that is also congruent to 1 mod 2N
+        uint64_t next_test_val = to1Coset(last_prime);
+
+        while (!miller_rabin_test(next_test_val, 25) || contains(next_test_val, mods)) {
+            next_test_val += two_n;
+        }
+        return next_test_val;
+    }
+
+    uint64_t prevPrime(uint64_t last_prime, uint64_t two_n, const vector<Modulus> &mods) {
+        // get the closest prime to `last_prime` that is also congruent to 1 mod 2N
+        uint64_t next_test_val = to1Coset(last_prime);
+
+        while (!miller_rabin_test(next_test_val, 25) || contains(next_test_val, mods)) {
+            next_test_val -= two_n;
+        }
+        return next_test_val;
+    }
+
+    // implements the prime selection algorithm in https://eprint.iacr.org/2020/1118, Algorithm 3
+    vector<Modulus> reducedErrorPrimes(int poly_mod_degree, const vector<int> &modulus_vec) {
+        int num_moduli = modulus_vec.size();
+        vector<Modulus> primes(num_moduli);
+        uint64_t n = 2 * poly_mod_degree;
+
+        // generate a prime for keyswitching
+        // this is independent of the ciphertext chain
+        primes[num_moduli - 1] = prevPrime(to1Coset(pow(2, modulus_vec[num_moduli - 1]), n), n, primes);
+        primes[num_moduli - 2] = nextPrime(to1Coset(pow(2, modulus_vec[num_moduli - 2]), n), n, primes);
+        double delta = static_cast<double>(primes[num_moduli - 2].value());
+        bool flip = false;
+        for (int l = num_moduli - 3; l > 0; l--) {
+            delta = delta * delta / static_cast<double>(primes[l + 1].value());
+            uint64_t round_delta = static_cast<uint64_t>(delta);
+            if (flip) {
+                primes[l] = prevPrime(to1Coset(round_delta, n), n, primes);
+            } else {
+                primes[l] = nextPrime(to1Coset(round_delta, n), n, primes);
+            }
+            flip = !flip;
+        }
+        primes[0] = prevPrime(to1Coset(pow(2, modulus_vec[0]), n), n, primes);
+        return primes;
+    }
+
     CKKSParams::CKKSParams(int num_slots, int max_ct_level, int log_scale, bool use_standard_params)
         : log_scale_(log_scale), use_std_params_(use_standard_params) {
         if (max_ct_level < 0) {
@@ -17,7 +98,9 @@ namespace hit {
         int poly_modulus_degree = num_slots * 2;
         params.set_poly_modulus_degree(poly_modulus_degree);
         vector<int> modulus_vec = gen_modulus_vec(max_ct_level + 2, log_scale);
-        params.set_coeff_modulus(CoeffModulus::Create(poly_modulus_degree, modulus_vec));
+        // vector<Modulus> mods = CoeffModulus::Create(poly_modulus_degree, modulus_vec);
+        vector<Modulus> mods = reducedErrorPrimes(poly_modulus_degree, modulus_vec);
+        params.set_coeff_modulus(mods);
     }
 
     CKKSParams::CKKSParams(EncryptionParameters params, int log_scale, bool use_standard_params)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
In RNS-CKKS, ciphertexts are "supposed" to have a "constant" scale `\Delta`. In reality, the scale at any given level `i` is `\Delta_i` = `\Delta_{i+1}^2/q_{i+1}`. Therefore, the way that the primes are selected can affect the speed at which `\Delta_i` diverges from the "target scale" `\Delta`. When the ciphertext scale diverges noticeably from `\Delta`, Bad Things happen to precision and correctness of the underlying computation.

SEAL chooses strictly ordered primes near the target scale. For example, if the target scale is 2^40, SEAL finds the first prime by decrementing (with an appropriate step size) from 2^40 until the first prime is found. For each consecutive prime, it continues to decrement until the next smallest prime is found. Thus 2^40 > q_{\ell} > q_{\ell-1} > .... This means that the scale _rapidly_ diverges from the target 2^40, since `\Delta_{\ell-1}=(2^40)^2/q_{\ell} > 2^40`, and therefore `\Delta_{\ell-2}` is even _larger_, and so on.

https://eprint.iacr.org/2020/1118 gives an algorithm (Algorithm 3) for selecting primes to delay divergence of `\Delta_i` from `\Delta` for as long as possible. This PR implements that prime selection algorithm on the SEAL branch.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
