### PR TITLE
Improved bootstrap API

### DIFF
--- a/src/hit/api/evaluator.cpp
+++ b/src/hit/api/evaluator.cpp
@@ -378,13 +378,18 @@ namespace hit {
     }
 
     CKKSCiphertext CKKSEvaluator::bootstrap(const CKKSCiphertext &ct, bool rescale_for_bootstrapping) {
+        CKKSCiphertext output = ct;
+        bootstrap_inplace(output, rescale_for_bootstrapping);
+        return output;
+    }
+
+    void CKKSEvaluator::bootstrap_inplace(CKKSCiphertext &ct, bool rescale_for_bootstrapping) {
         VLOG(VLOG_EVAL) << "Bootstrapping ciphertext";
-        CKKSCiphertext ct_prime = bootstrap_internal(ct, rescale_for_bootstrapping);
-        ct_prime.bootstrapped_ = true;
-        ct_prime.needs_relin_ = false;
-        ct_prime.needs_rescale_ = false;
-        print_stats(ct_prime);
-        return ct_prime;
+        bootstrap_inplace_internal(ct, rescale_for_bootstrapping);
+        ct.bootstrapped_ = true;
+        ct.needs_relin_ = false;
+        ct.needs_rescale_ = false;
+        print_stats(ct);
     }
 
     void CKKSEvaluator::rotate_right_inplace_internal(CKKSCiphertext &, int){};
@@ -404,7 +409,5 @@ namespace hit {
     void CKKSEvaluator::rescale_to_next_inplace_internal(CKKSCiphertext &){};
     void CKKSEvaluator::relinearize_inplace_internal(CKKSCiphertext &){};
     void CKKSEvaluator::print_stats(const CKKSCiphertext &){};
-    CKKSCiphertext CKKSEvaluator::bootstrap_internal(const CKKSCiphertext &ct, bool) {
-        return ct;
-    };
+    void CKKSEvaluator::bootstrap_inplace_internal(CKKSCiphertext &, bool) {};
 }  // namespace hit

--- a/src/hit/api/evaluator.cpp
+++ b/src/hit/api/evaluator.cpp
@@ -409,5 +409,5 @@ namespace hit {
     void CKKSEvaluator::rescale_to_next_inplace_internal(CKKSCiphertext &){};
     void CKKSEvaluator::relinearize_inplace_internal(CKKSCiphertext &){};
     void CKKSEvaluator::print_stats(const CKKSCiphertext &){};
-    void CKKSEvaluator::bootstrap_inplace_internal(CKKSCiphertext &, bool) {};
+    void CKKSEvaluator::bootstrap_inplace_internal(CKKSCiphertext &, bool){};
 }  // namespace hit

--- a/src/hit/api/evaluator.h
+++ b/src/hit/api/evaluator.h
@@ -358,6 +358,7 @@ namespace hit {
          * the default value of `true`.
          */
         CKKSCiphertext bootstrap(const CKKSCiphertext &ct, bool rescale_for_bootstrapping = true);
+        void bootstrap_inplace(CKKSCiphertext &ct, bool rescale_for_bootstrapping = true);
 
        protected:
         virtual void rotate_right_inplace_internal(CKKSCiphertext &ct, int steps);
@@ -378,7 +379,7 @@ namespace hit {
         virtual void relinearize_inplace_internal(CKKSCiphertext &ct);
         virtual void print_stats(const CKKSCiphertext &ct);
         virtual uint64_t get_last_prime_internal(const CKKSCiphertext &ct) const;
-        virtual CKKSCiphertext bootstrap_internal(const CKKSCiphertext &ct, bool rescale_for_bootstrapping);
+        virtual void bootstrap_inplace_internal(CKKSCiphertext &ct, bool rescale_for_bootstrapping);
 
         void reduce_metadata_to_level(CKKSCiphertext &ct, int level);
         void rescale_metata_to_next(CKKSCiphertext &ct);

--- a/src/hit/api/evaluator/debug.cpp
+++ b/src/hit/api/evaluator/debug.cpp
@@ -313,11 +313,8 @@ namespace hit {
         scale_estimator->relinearize_inplace_internal(ct);
     }
 
-    CKKSCiphertext DebugEval::bootstrap_internal(const CKKSCiphertext &ct, bool rescale_for_bootstrapping) {
-        CKKSCiphertext ctout = homomorphic_eval->bootstrap_internal(ct, rescale_for_bootstrapping);
-        // homomorphic evaluator updates all necessary metadata; we can ignore the scale_estimator output.
-        // but we still need to *call* the scale_estimator (on the orignal input) so that it updates the internal state
-        scale_estimator->bootstrap_internal(ct, rescale_for_bootstrapping);
-        return ctout;
+    void DebugEval::bootstrap_inplace_internal(CKKSCiphertext &ct, bool rescale_for_bootstrapping) {
+        homomorphic_eval->bootstrap_inplace_internal(ct, rescale_for_bootstrapping);
+        scale_estimator->bootstrap_inplace_internal(ct, rescale_for_bootstrapping);
     }
 }  // namespace hit

--- a/src/hit/api/evaluator/debug.h
+++ b/src/hit/api/evaluator/debug.h
@@ -83,7 +83,7 @@ namespace hit {
 
         void relinearize_inplace_internal(CKKSCiphertext &ct) override;
 
-        CKKSCiphertext bootstrap_internal(const CKKSCiphertext &ct, bool rescale_for_bootstrapping) override;
+        void bootstrap_inplace_internal(CKKSCiphertext &ct, bool rescale_for_bootstrapping) override;
 
        private:
         uint64_t get_last_prime_internal(const CKKSCiphertext &ct) const override;

--- a/src/hit/api/evaluator/explicitdepthfinder.cpp
+++ b/src/hit/api/evaluator/explicitdepthfinder.cpp
@@ -123,7 +123,7 @@ namespace hit {
         // CT level is adjusted in CKKSEvaluator::rescale_metata_to_next
     }
 
-    CKKSCiphertext ExplicitDepthFinder::bootstrap_internal(const CKKSCiphertext &ct, bool rescale_for_bootstrapping) {
+    void ExplicitDepthFinder::bootstrap_inplace_internal(CKKSCiphertext &ct, bool rescale_for_bootstrapping) {
         scoped_lock lock(mutex_);
         // if rescale_for_bootstrapping, bootstrapping will implicitly consume one additional level to rescale the
         // ciphertext first, ensure that if explict levels are set, we aren't already at level 0
@@ -139,9 +139,7 @@ namespace hit {
         }
         uses_bootstrapping = true;
         // CT bootstrapped_ is adjusted in CKKSEvaluator::bootstrap
-        CKKSCiphertext bootstrapped_ct = ct;
-        bootstrapped_ct.he_level_ = 0;
-        return bootstrapped_ct;
+        ct.he_level_ = 0;
     }
 
     int ExplicitDepthFinder::get_param_bootstrap_depth() const {

--- a/src/hit/api/evaluator/explicitdepthfinder.h
+++ b/src/hit/api/evaluator/explicitdepthfinder.h
@@ -74,7 +74,7 @@ namespace hit {
 
         void rescale_to_next_inplace_internal(CKKSCiphertext &ct) override;
 
-        CKKSCiphertext bootstrap_internal(const CKKSCiphertext &ct, bool rescale_for_bootstrapping) override;
+        void bootstrap_inplace_internal(CKKSCiphertext &ct, bool rescale_for_bootstrapping) override;
 
        private:
         const int num_slots_ = 4096;

--- a/src/hit/api/evaluator/homomorphic.cpp
+++ b/src/hit/api/evaluator/homomorphic.cpp
@@ -185,6 +185,7 @@ namespace hit {
         for (int i = context->max_ciphertext_level() - btp_depth; i > level; i--) {
             scale = (scale * scale) / static_cast<double>(context->get_qi(i));
         }
+        cout << "Encrypting at level " << level << " and logScale " << log2(scale) << endl;
 
         CKKSCiphertext destination;
         destination.he_level_ = level;
@@ -345,7 +346,7 @@ namespace hit {
         relinearize(get_evaluator().ref(), ct.backend_ct, ct.backend_ct);
     }
 
-    CKKSCiphertext HomomorphicEval::bootstrap_internal(const CKKSCiphertext &ct, bool rescale_for_bootstrapping) {
+    void HomomorphicEval::bootstrap_inplace_internal(CKKSCiphertext &ct, bool rescale_for_bootstrapping) {
         // if rescale_for_bootstrapping is set, the circuit designer expects that one level will be consumed
         // _prior_ to bootstrapping in order to rescale the ciphertext for bootstrapping (which has specific
         // requirements on the scale). Note that this rescale is implicit: it's part of Lattigo's `bootstrap`
@@ -355,16 +356,13 @@ namespace hit {
             LOG_AND_THROW_STREAM("Unable to bootstrap ciphertext at level 0 when rescale_for_bootstrapping is true.");
         }
 
-        CKKSCiphertext bootstrapped_ct = ct;
-
         // Note that we don't actually *use* `rescale_for_bootstrapping`: it is a "HIT-ism" which
         // is required by other evaluators (notably the DepthFinder evaluators, since this parameter
         // affects circuit depth). However, we don't pass it to the Lattigo bootstrap API because
         // Lattigo implicitly does the rescale if it's able to. For more information, see the
         // API comment in evaluator.h.
-        bootstrapped_ct.backend_ct = latticpp::bootstrap(get_bootstrapper().ref(), ct.backend_ct);
-        bootstrapped_ct.scale_ = pow(2, context->log_scale());
-        bootstrapped_ct.he_level_ = context->max_ciphertext_level() - btp_depth;
-        return bootstrapped_ct;
+        ct.backend_ct = latticpp::bootstrap(get_bootstrapper().ref(), ct.backend_ct);
+        ct.scale_ = pow(2, context->log_scale());
+        ct.he_level_ = context->max_ciphertext_level() - btp_depth;
     }
 }  // namespace hit

--- a/src/hit/api/evaluator/homomorphic.cpp
+++ b/src/hit/api/evaluator/homomorphic.cpp
@@ -185,7 +185,6 @@ namespace hit {
         for (int i = context->max_ciphertext_level() - btp_depth; i > level; i--) {
             scale = (scale * scale) / static_cast<double>(context->get_qi(i));
         }
-        cout << "Encrypting at level " << level << " and logScale " << log2(scale) << endl;
 
         CKKSCiphertext destination;
         destination.he_level_ = level;

--- a/src/hit/api/evaluator/homomorphic.h
+++ b/src/hit/api/evaluator/homomorphic.h
@@ -102,7 +102,7 @@ namespace hit {
 
         void relinearize_inplace_internal(CKKSCiphertext &ct) override;
 
-        CKKSCiphertext bootstrap_internal(const CKKSCiphertext &ct, bool rescale_for_bootstrapping) override;
+        void bootstrap_inplace_internal(CKKSCiphertext &ct, bool rescale_for_bootstrapping) override;
 
        private:
         template <typename T>

--- a/src/hit/api/evaluator/implicitdepthfinder.cpp
+++ b/src/hit/api/evaluator/implicitdepthfinder.cpp
@@ -106,8 +106,7 @@ namespace hit {
         // CT level is adjusted in CKKSEvaluator::rescale_metata_to_next
     }
 
-    CKKSCiphertext ImplicitDepthFinder::bootstrap_internal(const CKKSCiphertext &ct, bool rescale_for_bootstrapping) {
-        CKKSCiphertext bootstrapped_ct = ct;
+    void ImplicitDepthFinder::bootstrap_inplace_internal(CKKSCiphertext &ct, bool rescale_for_bootstrapping) {
         scoped_lock lock(mutex_);
         if (ct.bootstrapped_) {
             // this ciphertext has already been bootstrapped
@@ -119,9 +118,8 @@ namespace hit {
                 max(max_contiguous_depth, static_cast<int>(rescale_for_bootstrapping) - ct.he_level());
         }
         // CT bootstrapped_ is adjusted in CKKSEvaluator::bootstrap
-        bootstrapped_ct.he_level_ = 0;
+        ct.he_level_ = 0;
         uses_bootstrapping = true;
-        return bootstrapped_ct;
     }
 
     int ImplicitDepthFinder::get_param_bootstrap_depth() const {

--- a/src/hit/api/evaluator/implicitdepthfinder.h
+++ b/src/hit/api/evaluator/implicitdepthfinder.h
@@ -73,7 +73,7 @@ namespace hit {
 
         void rescale_to_next_inplace_internal(CKKSCiphertext &ct) override;
 
-        CKKSCiphertext bootstrap_internal(const CKKSCiphertext &ct, bool rescale_for_bootstrapping) override;
+        void bootstrap_inplace_internal(CKKSCiphertext &ct, bool rescale_for_bootstrapping) override;
 
        private:
         const int num_slots_ = 4096;

--- a/src/hit/api/evaluator/opcount.cpp
+++ b/src/hit/api/evaluator/opcount.cpp
@@ -125,9 +125,8 @@ namespace hit {
         relins_++;
     }
 
-    CKKSCiphertext OpCount::bootstrap_internal(const CKKSCiphertext &ct, bool) {
+    void OpCount::bootstrap_inplace_internal(CKKSCiphertext &, bool) {
         scoped_lock lock(mutex_);
         bootstraps_++;
-        return ct;
     }
 }  // namespace hit

--- a/src/hit/api/evaluator/opcount.h
+++ b/src/hit/api/evaluator/opcount.h
@@ -60,7 +60,7 @@ namespace hit {
 
         void relinearize_inplace_internal(CKKSCiphertext &ct) override;
 
-        CKKSCiphertext bootstrap_internal(const CKKSCiphertext &ct, bool rescale_for_bootstrapping) override;
+        void bootstrap_inplace_internal(CKKSCiphertext &ct, bool rescale_for_bootstrapping) override;
 
         int num_slots() const override;
 

--- a/src/hit/api/evaluator/scaleestimator.cpp
+++ b/src/hit/api/evaluator/scaleestimator.cpp
@@ -244,17 +244,15 @@ namespace hit {
         ct.scale_ = input_scale;
     }
 
-    CKKSCiphertext ScaleEstimator::bootstrap_internal(const CKKSCiphertext &ct, bool) {
+    void ScaleEstimator::bootstrap_inplace_internal(CKKSCiphertext &ct, bool) {
         if (btp_depth == 0) {
             LOG_AND_THROW_STREAM("Parameters do not support bootstrapping.");
         }
 
-        CKKSCiphertext ctout = ct;
-        ctout.scale_ = pow(2, context->log_scale());
-        ctout.he_level_ = context->max_ciphertext_level() - btp_depth;
+        ct.scale_ = pow(2, context->log_scale());
+        ct.he_level_ = context->max_ciphertext_level() - btp_depth;
 
-        update_max_log_scale(ctout);
-        return ctout;
+        update_max_log_scale(ct);
     }
 
     double ScaleEstimator::get_estimated_max_log_scale() const {

--- a/src/hit/api/evaluator/scaleestimator.h
+++ b/src/hit/api/evaluator/scaleestimator.h
@@ -80,7 +80,7 @@ namespace hit {
 
         void rescale_to_next_inplace_internal(CKKSCiphertext &ct) override;
 
-        CKKSCiphertext bootstrap_internal(const CKKSCiphertext &ct, bool rescale_for_bootstrapping) override;
+        void bootstrap_inplace_internal(CKKSCiphertext &ct, bool rescale_for_bootstrapping) override;
 
        private:
         ScaleEstimator(int num_slots, const HomomorphicEval &homom_eval);

--- a/src/hit/api/linearalgebra/linearalgebra.h
+++ b/src/hit/api/linearalgebra/linearalgebra.h
@@ -1135,7 +1135,7 @@ namespace hit {
         template <typename T>
         T bootstrap(const T &arg, bool rescale_for_bootstrapping = true) {
             T temp = arg;
-            bootstrap(temp, rescale_for_bootstrapping);
+            bootstrap_inplace(temp, rescale_for_bootstrapping);
             return temp;
         }
 

--- a/src/hit/api/linearalgebra/linearalgebra.h
+++ b/src/hit/api/linearalgebra/linearalgebra.h
@@ -1133,15 +1133,27 @@ namespace hit {
          * NOTE: Inputs which are linear ciphertexts to begin with are unchanged by this function.
          */
         template <typename T>
-        T bootstrap(T &arg, bool rescale_for_bootstrapping = true) {
+        T bootstrap(const T &arg, bool rescale_for_bootstrapping = true) {
+            T temp = arg;
+            bootstrap(temp, rescale_for_bootstrapping);
+            return temp;
+        }
+
+        /* Bootstrap each ciphertext corresponding to the encrypted linear algebra
+         * object.
+         * Input: A quadratic EncryptedMatrix, EncryptedRowVector, or EncryptedColVector
+         *        with nominal or squared scale.
+         * Output (Inplace): A linear ciphertext with the same scale and level as the input.
+         * NOTE: Inputs which are linear ciphertexts to begin with are unchanged by this function.
+         */
+        template <typename T>
+        void bootstrap_inplace(T &arg, bool rescale_for_bootstrapping = true) {
             TRY_AND_THROW_STREAM(arg.validate(), "Argument to bootstrap is invalid; has it been initialized?");
 
-            T bootstrapped_t = arg;
             // Bootstrapping seems too memory-intensive to do in parallel
             for (int i = 0; i < arg.num_cts(); i++) {
-                bootstrapped_t[i] = eval.bootstrap(arg[i], rescale_for_bootstrapping);
+                eval.bootstrap_inplace(arg[i], rescale_for_bootstrapping);
             }
-            return bootstrapped_t;
         }
 
         CKKSEvaluator &eval;


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Adds a `bootstrap_inplace` API. When I wrote the bootstrapping API the first time, for some reason I thought I couldn't have `bootstrap_inplace` (something might have been different in the older version of `lattigo`). Whatever the reason, `bootstrap_inplace` is perfectly fine now, and it simplifies things quite a bit.

This also fixes a bug where the `bootstrap` API was modifying its (`const`!) input. The root cause for the bug is tracked [here](https://github.com/ldsec/lattigo/issues/141). In short, `homomorphic.cpp` copied its input and then called `lattigo::bootstrap` on the _original_ input. This _should_ be fine, because the `lattigo::bootstrap` API should not modify its input. However, `lattigo::bootstrap` _does_ modify its input, meaning that the `const` input to a C++ function was getting modified, which unsurprisingly, resulted in unexpected behavior.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
